### PR TITLE
Removed dependency on russh, updated example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["russh", "sftp", "ssh2", "server", "client"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1", default-features = false, features = ["io-util", "rt"] }
 
 num-derive = "0.3"
 num-traits = "0.2"
@@ -19,7 +19,6 @@ num = "0.4"
 
 futures = "0.3"
 async-trait = "0.1"
-russh = "0.35.0-beta.8"
 thiserror = "1.0"
 bitflags = "1.3"
 chrono = "0.4"
@@ -27,6 +26,7 @@ bytes = "1.3"
 log = "0.4"
 
 [dev-dependencies]
+russh = "0.35.0-beta.8"
 russh-keys = "0.23.0-beta.1"
 env_logger = "0.10"
 anyhow = "1.0"


### PR DESCRIPTION
* Changed parameter type in `run` to `AsyncRead + AsyncWrite`, removing direct dependency on `russh`
* Cleaned up & updated the example to allow running `ls` 

If you could merge this and make a new release, I can then add a usage example to russh :)