### PR TITLE
Fix StatusCode typo

### DIFF
--- a/src/protocol/status.rs
+++ b/src/protocol/status.rs
@@ -11,22 +11,37 @@ use super::impl_packet_for;
 /// Error Codes for SSH_FXP_STATUS
 #[derive(Debug, Error, Clone, Copy, PartialEq, Eq, FromPrimitive)]
 pub enum StatusCode {
+    /// Indicates successful completion of the operation.
     #[error("Ok")]
     Ok = 0,
+    /// Indicates end-of-file condition; for SSH_FX_READ it means that no more data is available in the file,
+    /// and for SSH_FX_READDIR it indicates that no more files are contained in the directory.
     #[error("Eof")]
     Eof = 1,
+    /// A reference is made to a file which should exist but doesn't.
     #[error("No such file")]
     NoSuchFile = 2,
-    #[error("Permission denined")]
-    PermissionDenined = 3,
+    /// Authenticated user does not have sufficient permissions to perform the operation.
+    #[error("Permission denied")]
+    PermissionDenied = 3,
+    /// A generic catch-all error message;
+    /// it should be returned if an error occurs for which there is no more specific error code defined.
     #[error("Failure")]
     Failure = 4,
+    /// May be returned if a badly formatted packet or protocol incompatibility is detected.
     #[error("Bad message")]
     BadMessage = 5,
+    /// A pseudo-error which indicates that the client has no connection to the server
+    /// (it can only be generated locally by the client, and MUST NOT be returned by servers).
     #[error("No connection")]
     NoConnection = 6,
+    /// A pseudo-error which indicates that the connection to the server has been lost
+    /// (it can only be generated locally by the client, and MUST NOT be returned by servers).
     #[error("Connection lost")]
     ConnectionLost = 7,
+    /// Indicates that an attempt was made to perform an operation which is not supported for the server
+    /// (it may be generated locally by the client if e.g. the version number exchange indicates that a required feature is not supported by the server,
+    /// or it may be returned by the server if the server does not implement an operation).
     #[error("Operation unsupported")]
     OpUnsupported = 8,
 }


### PR DESCRIPTION
There is a typo as `StatusCode::PermissionDenined`. So I fixed it and added documentation for each status code from the SFTP specification (https://filezilla-project.org/specs/draft-ietf-secsh-filexfer-02.txt) as it helps the user to choose which code to return.

Hope this is fine for you. Have a great day.