### PR TITLE
Make `error` module public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@ mod buf;
 /// Client side
 pub mod client;
 pub mod de;
-mod error;
+pub mod error;
 pub mod extensions;
 /// Protocol implementation
 pub mod protocol;


### PR DESCRIPTION
Make `error` module public so it can be used by downstream consumers.