### PR TITLE
Add client support for `statvfs@openssh.com` v2 extension.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The main idea of the project is to provide an implementation for interacting wit
 - [x] Client example
 - [x] Server side
 - [x] Simple server example
-- [x] Extension support: `limits@openssh.com`, `fsync@openssh.com`
+- [x] Extension support: `limits@openssh.com`, `fsync@openssh.com`, `statvfs@openssh.com`
 - [ ] Full server example
 - [ ] Unit tests
 - [ ] Workflow

--- a/src/extensions.rs
+++ b/src/extensions.rs
@@ -20,3 +20,46 @@ impl TryInto<Vec<u8>> for FsyncExtension {
         ser::to_bytes(&self).map(|b| b.to_vec())
     }
 }
+
+pub const STATVFS: &str = "statvfs@openssh.com";
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct StatvfsExtension {
+    pub path: String,
+}
+
+impl TryInto<Vec<u8>> for StatvfsExtension {
+    type Error = Error;
+
+    fn try_into(self) -> Result<Vec<u8>, Self::Error> {
+        ser::to_bytes(&self).map(|b| b.to_vec())
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Statvfs {
+    /// The file system block size
+    pub block_size: u64,
+    /// The fundamental file system block size
+    pub fragment_size: u64,
+    /// The number of blocks.
+    ///
+    /// Units are in units of `fragment_size`
+    pub blocks: u64,
+    /// The number of free blocks in the file system
+    pub blocks_free: u64,
+    /// The number of free blocks for unprivileged users
+    pub blocks_avail: u64,
+    /// The total number of file inodes
+    pub inodes: u64,
+    /// The number of free file inodes
+    pub inodes_free: u64,
+    /// The number of free file inodes for unprivileged users
+    pub inodes_avail: u64,
+    /// The file system id
+    pub fs_id: u64,
+    /// The mount flags
+    pub flags: u64,
+    /// The maximum filename length
+    pub name_max: u64,
+}


### PR DESCRIPTION
This patch adds client support for `statvfs@openssh.com` v2 extension