### PR TITLE
Performance optimization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,18 @@ thiserror = "1.0"
 chrono = "0.4"
 bytes = "1.5"
 log = "0.4"
+flurry = "0.4.0"
 
 [dev-dependencies]
 russh = "0.39"
 russh-keys = "0.38"
 env_logger = "0.10"
 anyhow = "1.0"
+perfcnt = "0.8.0"
+criterion-perf-events = "0.3.0"
+criterion = {version = "0.4", features = ["async_tokio"] }
+futures = "0.3.29"
+
+[[bench]]
+name = "my_benchmark"
+harness = false

--- a/benches/my_benchmark.rs
+++ b/benches/my_benchmark.rs
@@ -1,0 +1,99 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use criterion::{criterion_group, criterion_main, Criterion};
+use futures;
+use log::debug;
+use russh::{client, ChannelId};
+use russh_keys::key;
+use russh_sftp::client::SftpSession;
+use tokio::{
+    io::AsyncWriteExt,
+    task::{self},
+    time::Instant,
+};
+struct Client;
+
+#[async_trait]
+impl client::Handler for Client {
+    type Error = anyhow::Error;
+
+    async fn check_server_key(
+        self,
+        server_public_key: &key::PublicKey,
+    ) -> Result<(Self, bool), Self::Error> {
+        debug!("check_server_key: {:?}", server_public_key);
+        Ok((self, true))
+    }
+
+    async fn data(
+        self,
+        channel: ChannelId,
+        data: &[u8],
+        session: client::Session,
+    ) -> Result<(Self, client::Session), Self::Error> {
+        debug!("data on channel {:?}: {}", channel, data.len());
+        Ok((self, session))
+    }
+}
+
+async fn test_upload_data(mut sftp: SftpSession, file_count: i32, file_size: i32) {
+    let data_vec: Vec<u8> = vec![0; file_size as usize];
+    let mut handler_vec = Vec::new();
+    let start_time = Instant::now();
+    for i in 0..file_count {
+        let path = format!("data-sync/test_{i}.txt");
+        let mut file = sftp.create(path).await.unwrap();
+        let data_vec_bk = data_vec.clone();
+        let handler = task::spawn(async move {
+            let start_time = Instant::now();
+            file.write_all(&data_vec_bk).await.unwrap();
+            let elapsed_time = start_time.elapsed();
+            println!("write_all Time elapsed: {:?}", elapsed_time);
+        });
+        handler_vec.push(handler);
+    }
+
+    futures::future::join_all(handler_vec).await;
+    let elapsed_time = start_time.elapsed();
+    println!("Time elapsed: {:?}", elapsed_time);
+    for i in 0..file_count {
+        let path = format!("data-sync/test_{i}.txt");
+        sftp.remove_file(path).await.unwrap();
+    }
+}
+
+async fn upload_file(file_count: i32, file_size: i32) {
+    let config = russh::client::Config::default();
+    let sh = Client {};
+    let mut session = russh::client::connect(Arc::new(config), ("localhost", 22), sh)
+        .await
+        .unwrap();
+    if session
+        .authenticate_password("sftp-user", "password")
+        .await
+        .unwrap()
+    {
+        let mut channel = session.channel_open_session().await.unwrap();
+        channel.request_subsystem(true, "sftp").await.unwrap();
+        let sftp = SftpSession::new(channel.into_stream()).await.unwrap();
+        test_upload_data(sftp, file_count, file_size).await;
+    }
+}
+
+fn criterion_benchmark_call(c: &mut Criterion) {
+    c.bench_function("call", move |b| {
+        b.to_async(tokio::runtime::Runtime::new().unwrap())
+            .iter(|| async {
+                //If higher concurrency is required, please set the semaphore for channel in the fn connect_stream()
+                upload_file(8, 1024 * 1024 * 10).await;
+            })
+    });
+}
+
+criterion_group!(
+    name = instructions_bench;
+    config = Criterion::default().sample_size(10);
+    targets = criterion_benchmark_call
+);
+criterion_main!(instructions_bench);

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -45,7 +45,7 @@ async fn main() {
     if session.authenticate_password("root", "pass").await.unwrap() {
         let mut channel = session.channel_open_session().await.unwrap();
         channel.request_subsystem(true, "sftp").await.unwrap();
-        let sftp = SftpSession::new(channel.into_stream()).await.unwrap();
+        let mut sftp = SftpSession::new(channel.into_stream()).await.unwrap();
         info!("current path: {:?}", sftp.canonicalize(".").await.unwrap());
 
         // create dir and symlink

--- a/src/client/fs/mod.rs
+++ b/src/client/fs/mod.rs
@@ -1,5 +1,5 @@
 //! Filesystem manipulation operations.
-//! 
+//!
 //! This module contains methods for interacting with remote entities on high-level.
 //! The architecture is quite simple because it is built as an analogue of [`std::fs`]
 

--- a/src/client/rawsession.rs
+++ b/src/client/rawsession.rs
@@ -1,8 +1,9 @@
 use bytes::Bytes;
+use flurry::HashMap;
 use std::{num::Wrapping, sync::Arc, time::Duration};
 use tokio::{
     io::{AsyncRead, AsyncWrite},
-    sync::{mpsc, oneshot, Mutex},
+    sync::{mpsc, Mutex},
     time::timeout,
 };
 
@@ -16,9 +17,9 @@ use crate::{
         Remove, Rename, RmDir, SetStat, Stat, Status, StatusCode, Symlink, Version, Write,
     },
 };
-
+use tokio::sync::mpsc::Sender;
 pub type SftpResult<T> = Result<T, Error>;
-type SharedData = Mutex<Vec<(Option<u32>, oneshot::Sender<SftpResult<Packet>>)>>;
+type SharedData = HashMap<String, Sender<SftpResult<Packet>>>;
 
 pub(crate) struct SessionInner {
     version: Option<u32>,
@@ -27,25 +28,18 @@ pub(crate) struct SessionInner {
 
 impl SessionInner {
     pub async fn reply(&mut self, id: Option<u32>, packet: Packet) -> SftpResult<()> {
-        let mut requests = self.requests.lock().await;
-
-        if let Some(idx) = requests.iter().position(|&(i, _)| i == id) {
-            let validate = if id.is_some() && self.version.is_none() {
-                Err(Error::UnexpectedPacket)
-            } else if id.is_none() && self.version.is_some() {
-                Err(Error::UnexpectedBehavior("Duplicate version".to_owned()))
-            } else {
-                Ok(())
-            };
-
-            let _ = requests
-                .remove(idx)
-                .1
-                .send(validate.clone().map(|_| packet));
-
+        let validate = if id.is_some() && self.version.is_none() {
+            Err(Error::UnexpectedPacket)
+        } else if id.is_none() && self.version.is_some() {
+            Err(Error::UnexpectedBehavior("Duplicate version".to_owned()))
+        } else {
+            Ok(())
+        };
+        let id = id.unwrap_or_default().to_string();
+        if let Some(sender) = self.requests.pin().remove(&id) {
+            sender.try_send(validate.clone().map(|_| packet)).unwrap();
             return validate;
         }
-
         Err(Error::UnexpectedBehavior(format!(
             "Packet {:?} for unknown recipient",
             id
@@ -58,7 +52,7 @@ impl Handler for SessionInner {
     type Error = Error;
 
     async fn version(&mut self, packet: Version) -> Result<(), Self::Error> {
-        let version = packet.version;
+        let version = packet.version.clone();
         self.reply(None, packet.into()).await?;
         self.version = Some(version);
         Ok(())
@@ -119,6 +113,7 @@ impl From<LimitsExtension> for Limits {
     }
 }
 
+#[derive(Debug, Clone)]
 pub(crate) struct Options {
     timeout: u64,
     limits: Arc<Limits>,
@@ -128,10 +123,11 @@ pub(crate) struct Options {
 /// If the server returns a `Status` packet and it has the code Ok
 /// then the packet is returned as Ok in other error cases
 /// the packet is stored as Err.
+#[derive(Debug, Clone)]
 pub struct RawSftpSession {
     tx: mpsc::UnboundedSender<Bytes>,
     requests: Arc<SharedData>,
-    next_req_id: u32,
+    next_req_id: Arc<Mutex<u32>>,
     handles: Wrapping<u64>,
     options: Options,
 }
@@ -161,16 +157,16 @@ impl RawSftpSession {
     where
         S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
     {
-        let arc = Arc::new(Mutex::new(Vec::new()));
+        let req_map = Arc::new(HashMap::new());
         let inner = SessionInner {
             version: None,
-            requests: arc.clone(),
+            requests: req_map.clone(),
         };
 
         Self {
             tx: run(stream, inner),
-            requests: arc,
-            next_req_id: 0,
+            requests: req_map,
+            next_req_id: Arc::new(Mutex::new(1)),
             handles: Wrapping(0),
             options: Options {
                 timeout: 10,
@@ -191,24 +187,28 @@ impl RawSftpSession {
     }
 
     async fn send(&self, id: Option<u32>, packet: Packet) -> SftpResult<Packet> {
-        let (tx, rx) = oneshot::channel();
-
-        self.requests.lock().await.push((id, tx));
+        let (tx, mut rx) = mpsc::channel(1);
+        let id = id.unwrap_or_default().to_string();
+        self.requests.pin().insert(id.clone(), tx);
         self.tx.send(Bytes::try_from(packet)?)?;
-
-        match timeout(Duration::from_secs(self.options.timeout), rx).await {
-            Ok(result) => result?,
+        match timeout(Duration::from_secs(self.options.timeout), rx.recv()).await {
+            Ok(Some(result)) => result,
+            Ok(None) => {
+                self.requests.pin().remove(&id);
+                Err(Error::UnexpectedBehavior("Recv None Message".into()))
+            }
             Err(error) => {
-                self.requests.lock().await.retain(|&(i, _)| i != id);
+                self.requests.pin().remove(&id);
                 Err(error.into())
             }
         }
     }
 
-    fn use_next_id(&mut self) -> u32 {
-        let id = self.next_req_id;
-        self.next_req_id += 1;
-        id
+    async fn use_next_id(&mut self) -> u32 {
+        let mut id = self.next_req_id.lock().await;
+        let id_value = id.clone();
+        *id += 1;
+        id_value
     }
 
     pub async fn init(&self) -> SftpResult<Version> {
@@ -235,7 +235,7 @@ impl RawSftpSession {
             return Err(Error::Limited("Handle limit reached".to_owned()));
         }
 
-        let id = self.use_next_id();
+        let id = self.use_next_id().await;
         let result = self
             .send(
                 Some(id),
@@ -257,7 +257,7 @@ impl RawSftpSession {
     }
 
     pub async fn close<H: Into<String>>(&mut self, handle: H) -> SftpResult<Status> {
-        let id = self.use_next_id();
+        let id = self.use_next_id().await;
         let result = self
             .send(
                 Some(id),
@@ -286,7 +286,7 @@ impl RawSftpSession {
             return Err(Error::Limited("Write limit reached".to_owned()));
         }
 
-        let id = self.use_next_id();
+        let id = self.use_next_id().await;
         let result = self
             .send(
                 Some(id),
@@ -318,7 +318,7 @@ impl RawSftpSession {
             return Err(Error::Limited("Write limit reached".to_owned()));
         }
 
-        let id = self.use_next_id();
+        let id = self.use_next_id().await;
         let result = self
             .send(
                 Some(id),
@@ -336,7 +336,7 @@ impl RawSftpSession {
     }
 
     pub async fn lstat<P: Into<String>>(&mut self, path: P) -> SftpResult<Attrs> {
-        let id = self.use_next_id();
+        let id = self.use_next_id().await;
         let result = self
             .send(
                 Some(id),
@@ -352,7 +352,7 @@ impl RawSftpSession {
     }
 
     pub async fn fstat<H: Into<String>>(&mut self, handle: H) -> SftpResult<Attrs> {
-        let id = self.use_next_id();
+        let id = self.use_next_id().await;
         let result = self
             .send(
                 Some(id),
@@ -372,7 +372,7 @@ impl RawSftpSession {
         path: P,
         attrs: FileAttributes,
     ) -> SftpResult<Status> {
-        let id = self.use_next_id();
+        let id = self.use_next_id().await;
         let result = self
             .send(
                 Some(id),
@@ -393,7 +393,7 @@ impl RawSftpSession {
         handle: H,
         attrs: FileAttributes,
     ) -> SftpResult<Status> {
-        let id = self.use_next_id();
+        let id = self.use_next_id().await;
         let result = self
             .send(
                 Some(id),
@@ -419,7 +419,7 @@ impl RawSftpSession {
             return Err(Error::Limited("Handle limit reached".to_owned()));
         }
 
-        let id = self.use_next_id();
+        let id = self.use_next_id().await;
         let result = self
             .send(
                 Some(id),
@@ -439,7 +439,7 @@ impl RawSftpSession {
     }
 
     pub async fn readdir<H: Into<String>>(&mut self, handle: H) -> SftpResult<Name> {
-        let id = self.use_next_id();
+        let id = self.use_next_id().await;
         let result = self
             .send(
                 Some(id),
@@ -455,7 +455,7 @@ impl RawSftpSession {
     }
 
     pub async fn remove<T: Into<String>>(&mut self, filename: T) -> SftpResult<Status> {
-        let id = self.use_next_id();
+        let id = self.use_next_id().await;
         let result = self
             .send(
                 Some(id),
@@ -475,7 +475,7 @@ impl RawSftpSession {
         path: P,
         attrs: FileAttributes,
     ) -> SftpResult<Status> {
-        let id = self.use_next_id();
+        let id = self.use_next_id().await;
         let result = self
             .send(
                 Some(id),
@@ -492,7 +492,7 @@ impl RawSftpSession {
     }
 
     pub async fn rmdir<P: Into<String>>(&mut self, path: P) -> SftpResult<Status> {
-        let id = self.use_next_id();
+        let id = self.use_next_id().await;
         let result = self
             .send(
                 Some(id),
@@ -508,7 +508,7 @@ impl RawSftpSession {
     }
 
     pub async fn realpath<P: Into<String>>(&mut self, path: P) -> SftpResult<Name> {
-        let id = self.use_next_id();
+        let id = self.use_next_id().await;
         let result = self
             .send(
                 Some(id),
@@ -524,7 +524,7 @@ impl RawSftpSession {
     }
 
     pub async fn stat<P: Into<String>>(&mut self, path: P) -> SftpResult<Attrs> {
-        let id = self.use_next_id();
+        let id = self.use_next_id().await;
         let result = self
             .send(
                 Some(id),
@@ -544,7 +544,7 @@ impl RawSftpSession {
         O: Into<String>,
         N: Into<String>,
     {
-        let id = self.use_next_id();
+        let id = self.use_next_id().await;
         let result = self
             .send(
                 Some(id),
@@ -561,7 +561,7 @@ impl RawSftpSession {
     }
 
     pub async fn readlink<P: Into<String>>(&mut self, path: P) -> SftpResult<Name> {
-        let id = self.use_next_id();
+        let id = self.use_next_id().await;
         let result = self
             .send(
                 Some(id),
@@ -581,7 +581,7 @@ impl RawSftpSession {
         P: Into<String>,
         T: Into<String>,
     {
-        let id = self.use_next_id();
+        let id = self.use_next_id().await;
         let result = self
             .send(
                 Some(id),
@@ -604,7 +604,7 @@ impl RawSftpSession {
         request: R,
         data: Vec<u8>,
     ) -> SftpResult<Packet> {
-        let id = self.use_next_id();
+        let id = self.use_next_id().await;
         self.send(
             Some(id),
             Extended {

--- a/src/client/session.rs
+++ b/src/client/session.rs
@@ -1,8 +1,5 @@
 use std::sync::Arc;
-use tokio::{
-    io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt},
-    sync::Mutex,
-};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
 use super::{
     error::Error,
@@ -25,7 +22,7 @@ pub(crate) struct Extensions {
 /// High-level SFTP implementation for easy interaction with a remote file system.
 /// Contains most methods similar to the native [filesystem](std::fs)
 pub struct SftpSession {
-    session: Arc<Mutex<RawSftpSession>>,
+    session: RawSftpSession,
     extensions: Arc<Extensions>,
 }
 
@@ -63,26 +60,26 @@ impl SftpSession {
         }
 
         Ok(Self {
-            session: Arc::new(Mutex::new(session)),
+            session,
             extensions: Arc::new(extensions),
         })
     }
 
     /// Set the maximum response time in seconds.
     /// Default: 10 seconds
-    pub async fn set_timeout(&self, secs: u64) {
-        self.session.lock().await.set_timeout(secs);
+    pub async fn set_timeout(&mut self, secs: u64) {
+        self.session.set_timeout(secs);
     }
 
     /// Attempts to open a file in read-only mode.
-    pub async fn open<T: Into<String>>(&self, filename: T) -> SftpResult<File> {
+    pub async fn open<T: Into<String>>(&mut self, filename: T) -> SftpResult<File> {
         self.open_with_flags(filename, OpenFlags::READ).await
     }
 
     /// Opens a file in write-only mode.
-    /// 
+    ///
     /// This function will create a file if it does not exist, and will truncate it if it does.
-    pub async fn create<T: Into<String>>(&self, filename: T) -> SftpResult<File> {
+    pub async fn create<T: Into<String>>(&mut self, filename: T) -> SftpResult<File> {
         self.open_with_flags(
             filename,
             OpenFlags::CREATE | OpenFlags::TRUNCATE | OpenFlags::WRITE,
@@ -92,14 +89,12 @@ impl SftpSession {
 
     /// Attempts to open or create the file in the specified mode
     pub async fn open_with_flags<T: Into<String>>(
-        &self,
+        &mut self,
         filename: T,
         flags: OpenFlags,
     ) -> SftpResult<File> {
         let handle = self
             .session
-            .lock()
-            .await
             .open(
                 filename,
                 flags,
@@ -119,8 +114,8 @@ impl SftpSession {
     }
 
     /// Requests the remote party for the absolute from the relative path.
-    pub async fn canonicalize<T: Into<String>>(&self, path: T) -> SftpResult<String> {
-        let name = self.session.lock().await.realpath(path).await?;
+    pub async fn canonicalize<T: Into<String>>(&mut self, path: T) -> SftpResult<String> {
+        let name = self.session.realpath(path).await?;
         match name.files.get(0) {
             Some(file) => Ok(file.filename.to_owned()),
             None => Err(Error::UnexpectedBehavior("no file".to_owned())),
@@ -128,17 +123,15 @@ impl SftpSession {
     }
 
     /// Creates a new empty directory.
-    pub async fn create_dir<T: Into<String>>(&self, path: T) -> SftpResult<()> {
+    pub async fn create_dir<T: Into<String>>(&mut self, path: T) -> SftpResult<()> {
         self.session
-            .lock()
-            .await
             .mkdir(path, FileAttributes::default())
             .await
             .map(|_| ())
     }
 
     /// Reads the contents of a file located at the specified path to the end.
-    pub async fn read<P: Into<String>>(&self, path: P) -> SftpResult<Vec<u8>> {
+    pub async fn read<P: Into<String>>(&mut self, path: P) -> SftpResult<Vec<u8>> {
         let mut file = self.open(path).await?;
         let mut buffer = Vec::new();
 
@@ -148,14 +141,14 @@ impl SftpSession {
     }
 
     /// Writes the contents to a file whose path is specified.
-    pub async fn write<P: Into<String>>(&self, path: P, data: &[u8]) -> SftpResult<()> {
+    pub async fn write<P: Into<String>>(&mut self, path: P, data: &[u8]) -> SftpResult<()> {
         let mut file = self.open_with_flags(path, OpenFlags::WRITE).await?;
         file.write_all(data).await?;
         Ok(())
     }
 
     /// Checks a file or folder exists at the specified path
-    pub async fn try_exists<P: Into<String>>(&self, path: P) -> SftpResult<bool> {
+    pub async fn try_exists<P: Into<String>>(&mut self, path: P) -> SftpResult<bool> {
         match self.metadata(path).await {
             Ok(_) => Ok(true),
             Err(Error::Status(status)) if status.status_code == StatusCode::NoSuchFile => Ok(false),
@@ -164,12 +157,12 @@ impl SftpSession {
     }
 
     /// Returns an iterator over the entries within a directory.
-    pub async fn read_dir<P: Into<String>>(&self, path: P) -> SftpResult<ReadDir> {
+    pub async fn read_dir<P: Into<String>>(&mut self, path: P) -> SftpResult<ReadDir> {
         let mut files = vec![];
-        let handle = self.session.lock().await.opendir(path).await?.handle;
+        let handle = self.session.opendir(path).await?.handle;
 
         loop {
-            match self.session.lock().await.readdir(handle.as_str()).await {
+            match self.session.readdir(handle.as_str()).await {
                 Ok(name) => {
                     files = name
                         .files
@@ -183,7 +176,7 @@ impl SftpSession {
             }
         }
 
-        self.session.lock().await.close(handle).await?;
+        self.session.close(handle).await?;
 
         Ok(ReadDir {
             entries: files.into(),
@@ -191,8 +184,8 @@ impl SftpSession {
     }
 
     /// Reads a symbolic link, returning the file that the link points to.
-    pub async fn read_link<P: Into<String>>(&self, path: P) -> SftpResult<String> {
-        let name = self.session.lock().await.readlink(path).await?;
+    pub async fn read_link<P: Into<String>>(&mut self, path: P) -> SftpResult<String> {
+        let name = self.session.readlink(path).await?;
         match name.files.get(0) {
             Some(file) => Ok(file.filename.to_owned()),
             None => Err(Error::UnexpectedBehavior("no file".to_owned())),
@@ -200,73 +193,58 @@ impl SftpSession {
     }
 
     /// Removes the specified folder.
-    pub async fn remove_dir<P: Into<String>>(&self, path: P) -> SftpResult<()> {
-        self.session.lock().await.rmdir(path).await.map(|_| ())
+    pub async fn remove_dir<P: Into<String>>(&mut self, path: P) -> SftpResult<()> {
+        self.session.rmdir(path).await.map(|_| ())
     }
 
     /// Removes the specified file.
-    pub async fn remove_file<T: Into<String>>(&self, filename: T) -> SftpResult<()> {
-        self.session.lock().await.remove(filename).await.map(|_| ())
+    pub async fn remove_file<T: Into<String>>(&mut self, filename: T) -> SftpResult<()> {
+        self.session.remove(filename).await.map(|_| ())
     }
 
     /// Rename a file or directory to a new name.
-    pub async fn rename<O, N>(&self, oldpath: O, newpath: N) -> SftpResult<()>
+    pub async fn rename<O, N>(&mut self, oldpath: O, newpath: N) -> SftpResult<()>
     where
         O: Into<String>,
         N: Into<String>,
     {
-        self.session
-            .lock()
-            .await
-            .rename(oldpath, newpath)
-            .await
-            .map(|_| ())
+        self.session.rename(oldpath, newpath).await.map(|_| ())
     }
 
     /// Creates a symlink of the specified target.
-    pub async fn symlink<P, T>(&self, path: P, target: T) -> SftpResult<()>
+    pub async fn symlink<P, T>(&mut self, path: P, target: T) -> SftpResult<()>
     where
         P: Into<String>,
         T: Into<String>,
     {
-        self.session
-            .lock()
-            .await
-            .symlink(path, target)
-            .await
-            .map(|_| ())
+        self.session.symlink(path, target).await.map(|_| ())
     }
 
     /// Queries metadata about the remote file.
-    pub async fn metadata<P: Into<String>>(&self, path: P) -> SftpResult<Metadata> {
-        Ok(self.session.lock().await.stat(path).await?.attrs)
+    pub async fn metadata<P: Into<String>>(&mut self, path: P) -> SftpResult<Metadata> {
+        Ok(self.session.stat(path).await?.attrs)
     }
 
     /// Sets metadata for a remote file.
     pub async fn set_metadata<P: Into<String>>(
-        &self,
+        &mut self,
         path: P,
         metadata: Metadata,
     ) -> Result<(), Error> {
-        self.session
-            .lock()
-            .await
-            .setstat(path, metadata)
-            .await
-            .map(|_| ())
+        self.session.setstat(path, metadata).await.map(|_| ())
     }
 
-    pub async fn symlink_metadata<P: Into<String>>(&self, path: P) -> SftpResult<Metadata> {
-        Ok(self.session.lock().await.lstat(path).await?.attrs)
+    pub async fn symlink_metadata<P: Into<String>>(&mut self, path: P) -> SftpResult<Metadata> {
+        Ok(self.session.lstat(path).await?.attrs)
     }
 
     /// Performs a statvfs on the remote file system path.
     /// Returns [`Ok(None)`] if the remote SFTP server does not support `statvfs@openssh.com` extension v2.
-    pub async fn fs_info<P: Into<String>>(&self, path: P) -> SftpResult<Option<Statvfs>> {
+    pub async fn fs_info<P: Into<String>>(&mut self, path: P) -> SftpResult<Option<Statvfs>> {
         if !self.extensions.statvfs {
             return Ok(None);
         }
 
-        self.session.lock().await.statvfs(path).await.map(Some)
+        self.session.statvfs(path).await.map(Some)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,17 +1,17 @@
 //! SFTP subsystem with client and server support for Russh and more!
-//! 
+//!
 //! Crate can provide compatibility with anything that can provide the raw data
 //! stream in and out of the subsystem channel.
-//! 
+//!
 //! The client implementation contains:
-//! 
+//!
 //! * Standard communication via [RawSftpSession](crate::client::RawSftpSession) which provides methods
-//!   for sending and receiving a packet in place. 
+//!   for sending and receiving a packet in place.
 //! * [High level](crate::client::SftpSession) is similar to [`std::fs`] and has almost all the same
 //!   implementations. Implements Async I/O for interaction with files. The main idea is to abstract
 //!   from all the nuances and flaws of the SFTP protocol. This also takes into account the extension
 //!   provided by the server provided by the server such as `limits@openssh.com` and `fsync@openssh.com`.
-//! 
+//!
 //! You can find more examples in the repository.
 
 #[macro_use]

--- a/src/protocol/init.rs
+++ b/src/protocol/init.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use super::{VERSION, impl_packet_for, Packet};
+use super::{impl_packet_for, Packet, VERSION};
 
 /// Implementation for SSH_FXP_INIT
 #[derive(Debug, Serialize, Deserialize)]

--- a/src/protocol/name.rs
+++ b/src/protocol/name.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use super::{impl_packet_for, impl_request_id, Packet, RequestId, File};
+use super::{impl_packet_for, impl_request_id, File, Packet, RequestId};
 
 /// Implementation for SSH_FXP_NAME
 #[derive(Debug, Serialize, Deserialize)]


### PR DESCRIPTION
close #10 


```sh
# run
cargo bench --bench my_benchmark -- --verbose
```
#### 8 files, each with a size of 10 MB, uploaded in approximately 3.3 seconds.  The speed is 24 MB/s.  
![image](https://github.com/AspectUnk/russh-sftp/assets/44500963/a5bc2724-9644-4d80-9624-69f8b9e58af7)

#### In fact, by [modifying the code to increase concurrency](https://github.com/warp-tech/russh/blob/271e362bdebc994aafaf340fb845d20125d0db09/russh/src/client/mod.rs#L671C15-L671C15), it is possible to achieve an upload speed of 30-40 MB/s. 
like this:
```rust
let (handle_sender, session_receiver) = channel(64);
```



