### PR TITLE
Call flush on stream in `russh-sftp::server::process_handler`

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -65,6 +65,7 @@ where
 
     let packet = Bytes::try_from(response)?;
     stream.write_all(&packet).await?;
+    stream.flush().await?;
 
     Ok(())
 }


### PR DESCRIPTION
Ensure data is always written and not buffered to the underlying device on every request.