### PR TITLE
Respond with EOF when finished listing directory

### DIFF
--- a/examples/server.rs
+++ b/examples/server.rs
@@ -162,7 +162,8 @@ impl russh_sftp::server::Handler for SftpSession {
                 ],
             });
         }
-        Ok(Name { id, files: vec![] })
+        // If all files have been sent to the client, respond with an EOF
+        Err(StatusCode::Eof)
     }
 
     async fn realpath(&mut self, id: u32, path: String) -> Result<Name, Self::Error> {


### PR DESCRIPTION
Thank you for the SFTP library!

I started to use it and noticed while testing different clients (sftp on the command line, paramiko with Python) that listing a directory running the basic server example does only work for sftp, but not paramiko. This seems to be related to [Paramiko expecting EOF](https://github.com/paramiko/paramiko/blob/51eb55debf2ebfe56f38378005439a029a48225f/paramiko/sftp_client.py#L247) to end a directory listing.
This matches the recommendation of the [v3 specification](https://datatracker.ietf.org/doc/html/draft-ietf-secsh-filexfer-02#section-6.7) as well as the [docs for this method](https://github.com/AspectUnk/russh-sftp/blob/master/src/server/handler.rs#L113) in russh-sftp itself.

Therefore I propose to have the server example follow this recommendation. I tested this locally with sftp and paramiko, both seem to work fine with this.

Have a nice weekend,
Christoph