### PR TITLE
Make File clonable

### DIFF
--- a/src/protocol/file.rs
+++ b/src/protocol/file.rs
@@ -3,7 +3,7 @@ use std::time::{Duration, UNIX_EPOCH};
 
 use super::FileAttributes;
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct File {
     pub filename: String,
     pub longname: String,


### PR DESCRIPTION
Greetings again!

Playing around with this library I found myself trying to to some 'virtual filesystem'-stuff. This involved re-using a few types from russh-sftp. I discovered (via `File`) that a lot of types there don't implement `Clone` though they easily could via derive.

I think that for most public types, especially the ones that get give to the user via the Handler trait should implement Clone. The setup of this trait requires a lot of things to be passed as owned values.

An example is the `russh_sftp::protocol::Name` struct taking an owned `Vec<File>`. I understand the design decision why this is the case, but then those `File`s need to come from somewhere. And if I already have them, it would be nice to be able to easily clone them.

One struct I did not add Clone to is `client::session::Session`. I added a test to keep this as is with a small explanation why.

Happy to hear any feedback on all this and feel free to let me know about other opinions on all of this!