### PR TITLE
Implement easy conversion for open options

### DIFF
--- a/src/protocol/open.rs
+++ b/src/protocol/open.rs
@@ -1,4 +1,4 @@
-use std::fs::OpenOptions;
+use std::fs;
 
 use super::{impl_packet_for, impl_request_id, FileAttributes, Packet, RequestId};
 
@@ -17,21 +17,9 @@ bitflags! {
     }
 }
 
-/// Implementation for SSH_FXP_OPEN
-#[derive(Debug, Serialize, Deserialize)]
-pub struct Open {
-    pub id: u32,
-    pub filename: String,
-    pub pflags: OpenFlags,
-    pub attrs: FileAttributes,
-}
-
-impl_request_id!(Open);
-impl_packet_for!(Open);
-
-impl From<OpenFlags> for OpenOptions {
+impl From<OpenFlags> for fs::OpenOptions {
     fn from(value: OpenFlags) -> Self {
-        let mut open_options = OpenOptions::new();
+        let mut open_options = fs::OpenOptions::new();
         if value.contains(OpenFlags::READ) {
             open_options.read(true);
         }
@@ -61,3 +49,15 @@ impl From<OpenFlags> for OpenOptions {
         open_options
     }
 }
+
+/// Implementation for SSH_FXP_OPEN
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Open {
+    pub id: u32,
+    pub filename: String,
+    pub pflags: OpenFlags,
+    pub attrs: FileAttributes,
+}
+
+impl_request_id!(Open);
+impl_packet_for!(Open);

--- a/src/protocol/open.rs
+++ b/src/protocol/open.rs
@@ -1,3 +1,5 @@
+use std::fs::OpenOptions;
+
 use super::{impl_packet_for, impl_request_id, FileAttributes, Packet, RequestId};
 
 /// Opening flags according to the specification
@@ -26,3 +28,36 @@ pub struct Open {
 
 impl_request_id!(Open);
 impl_packet_for!(Open);
+
+impl From<OpenFlags> for OpenOptions {
+    fn from(value: OpenFlags) -> Self {
+        let mut open_options = OpenOptions::new();
+        if value.contains(OpenFlags::READ) {
+            open_options.read(true);
+        }
+        if value.contains(OpenFlags::WRITE) {
+            open_options.write(true);
+        }
+        if value.contains(OpenFlags::APPEND) {
+            open_options.append(true);
+        }
+        if value.contains(OpenFlags::CREATE) {
+            // SFTPv3 spec requires the `CREATE` flag to be set if the `EXCLUDE` flag
+            // is set. Rusts `OpenOptions` has different semantics: it ignores
+            // whether `create` or `truncate` was set.
+            // SFTPv3 spec does not say anything about read/write flags, but
+            // they will be required to do anything else with the file.
+            // https://datatracker.ietf.org/doc/html/draft-ietf-secsh-filexfer-02#section-6.3
+            if value.contains(OpenFlags::EXCLUDE) {
+                open_options.create_new(true);
+            } else {
+                open_options.create(true);
+            }
+        }
+        if value.contains(OpenFlags::TRUNCATE) {
+            open_options.truncate(true);
+        }
+
+        open_options
+    }
+}


### PR DESCRIPTION
Greets!

Implementing a small server which allows users to upload files to directories ( straightforward, no magic :grin: ) I found myself coding the translation between `OpenFlags` and `tokio::fs::OpenOptions`.

They pretty much match up, so I think implementing `From` between those types would be a nice usability enhancement. I noticed that russh-sftp does not have the tokio fs feature enabled (totally correct), so instead I went ahead implementing `From<OpenFlags> for std::fs::OpenOptions`, there is a `From<std::fs::OpenOptions> for tokio::fs::OpenOptions` in tokio.

I think this still keeps the nice usability, only an extra call to `.into()` without having to worry about implementation details. And it does not require any other change to `russh-sftp`.

The only downside I see would be targeting non-std environments, but I don't think this is a concern for russh-sftp?

Have a nice day!
Christoph