### PR TITLE
client: Fix mangled packets beeing read when sending new requests.

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,7 +1,7 @@
 use bytes::Bytes;
 use chrono::{DateTime, Utc};
 use std::time::SystemTime;
-use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite};
+use tokio::io::{AsyncRead, AsyncReadExt};
 
 use crate::error::Error;
 
@@ -9,7 +9,7 @@ pub fn unix(time: SystemTime) -> u32 {
     DateTime::<Utc>::from(time).timestamp() as u32
 }
 
-pub async fn read_packet<S: AsyncRead + AsyncWrite + Unpin>(
+pub async fn read_packet<S: AsyncRead + Unpin>(
     stream: &mut S,
 ) -> Result<Bytes, Error> {
     let length = stream.read_u32().await?;


### PR DESCRIPTION
Fixes #33 

At the moment, receiving empty data from `rx` only closes the write half of the stream. I don't know whether that is enough to close the stream completely.