### PR TITLE
Use OsString instead of String so that paths are actually represented correctly

### DIFF
--- a/src/client/fs/dir.rs
+++ b/src/client/fs/dir.rs
@@ -1,4 +1,4 @@
-use std::collections::VecDeque;
+use std::{collections::VecDeque, ffi::OsString};
 
 use super::Metadata;
 use crate::protocol::FileType;
@@ -6,13 +6,13 @@ use crate::protocol::FileType;
 /// Entries returned by the [`ReadDir`] iterator.
 #[derive(Debug)]
 pub struct DirEntry {
-    file: String,
+    file: OsString,
     metadata: Metadata,
 }
 
 impl DirEntry {
     /// Returns the file name for the file that this entry points at.
-    pub fn file_name(&self) -> String {
+    pub fn file_name(&self) -> OsString {
         self.file.to_owned()
     }
 
@@ -29,7 +29,7 @@ impl DirEntry {
 
 /// Iterator over the entries in a remote directory.
 pub struct ReadDir {
-    pub(crate) entries: VecDeque<(String, Metadata)>,
+    pub(crate) entries: VecDeque<(OsString, Metadata)>,
 }
 
 impl Iterator for ReadDir {

--- a/src/client/rawsession.rs
+++ b/src/client/rawsession.rs
@@ -1,6 +1,7 @@
 use bytes::Bytes;
 use flurry::HashMap;
 use std::{
+    ffi::OsString,
     sync::{
         atomic::{AtomicU32, AtomicU64, Ordering},
         Arc,
@@ -660,8 +661,8 @@ impl RawSftpSession {
 
     pub async fn hardlink<O, N>(&self, oldpath: O, newpath: N) -> SftpResult<Status>
     where
-        O: Into<String>,
-        N: Into<String>,
+        O: Into<OsString>,
+        N: Into<OsString>,
     {
         let result = self
             .extended(
@@ -693,7 +694,7 @@ impl RawSftpSession {
 
     pub async fn statvfs<P>(&self, path: P) -> SftpResult<Statvfs>
     where
-        P: Into<String>,
+        P: Into<OsString>,
     {
         let result = self
             .extended(

--- a/src/client/rawsession.rs
+++ b/src/client/rawsession.rs
@@ -241,7 +241,7 @@ impl RawSftpSession {
         }
     }
 
-    pub async fn open<T: Into<String>>(
+    pub async fn open<T: Into<OsString>>(
         &self,
         filename: T,
         flags: OpenFlags,
@@ -369,7 +369,7 @@ impl RawSftpSession {
         into_status!(result)
     }
 
-    pub async fn lstat<P: Into<String>>(&self, path: P) -> SftpResult<Attrs> {
+    pub async fn lstat<P: Into<OsString>>(&self, path: P) -> SftpResult<Attrs> {
         let id = self.use_next_id();
         let result = self
             .send(
@@ -401,7 +401,7 @@ impl RawSftpSession {
         into_with_status!(result, Attrs)
     }
 
-    pub async fn setstat<P: Into<String>>(
+    pub async fn setstat<P: Into<OsString>>(
         &self,
         path: P,
         attrs: FileAttributes,
@@ -443,7 +443,7 @@ impl RawSftpSession {
         into_status!(result)
     }
 
-    pub async fn opendir<P: Into<String>>(&self, path: P) -> SftpResult<Handle> {
+    pub async fn opendir<P: Into<OsString>>(&self, path: P) -> SftpResult<Handle> {
         if self
             .options
             .limits
@@ -488,7 +488,7 @@ impl RawSftpSession {
         into_with_status!(result, Name)
     }
 
-    pub async fn remove<T: Into<String>>(&self, filename: T) -> SftpResult<Status> {
+    pub async fn remove<T: Into<OsString>>(&self, filename: T) -> SftpResult<Status> {
         let id = self.use_next_id();
         let result = self
             .send(
@@ -504,7 +504,7 @@ impl RawSftpSession {
         into_status!(result)
     }
 
-    pub async fn mkdir<P: Into<String>>(
+    pub async fn mkdir<P: Into<OsString>>(
         &self,
         path: P,
         attrs: FileAttributes,
@@ -525,7 +525,7 @@ impl RawSftpSession {
         into_status!(result)
     }
 
-    pub async fn rmdir<P: Into<String>>(&self, path: P) -> SftpResult<Status> {
+    pub async fn rmdir<P: Into<OsString>>(&self, path: P) -> SftpResult<Status> {
         let id = self.use_next_id();
         let result = self
             .send(
@@ -541,7 +541,7 @@ impl RawSftpSession {
         into_status!(result)
     }
 
-    pub async fn realpath<P: Into<String>>(&self, path: P) -> SftpResult<Name> {
+    pub async fn realpath<P: Into<OsString>>(&self, path: P) -> SftpResult<Name> {
         let id = self.use_next_id();
         let result = self
             .send(
@@ -557,7 +557,7 @@ impl RawSftpSession {
         into_with_status!(result, Name)
     }
 
-    pub async fn stat<P: Into<String>>(&self, path: P) -> SftpResult<Attrs> {
+    pub async fn stat<P: Into<OsString>>(&self, path: P) -> SftpResult<Attrs> {
         let id = self.use_next_id();
         let result = self
             .send(
@@ -575,8 +575,8 @@ impl RawSftpSession {
 
     pub async fn rename<O, N>(&self, oldpath: O, newpath: N) -> SftpResult<Status>
     where
-        O: Into<String>,
-        N: Into<String>,
+        O: Into<OsString>,
+        N: Into<OsString>,
     {
         let id = self.use_next_id();
         let result = self
@@ -594,7 +594,7 @@ impl RawSftpSession {
         into_status!(result)
     }
 
-    pub async fn readlink<P: Into<String>>(&self, path: P) -> SftpResult<Name> {
+    pub async fn readlink<P: Into<OsString>>(&self, path: P) -> SftpResult<Name> {
         let id = self.use_next_id();
         let result = self
             .send(
@@ -612,8 +612,8 @@ impl RawSftpSession {
 
     pub async fn symlink<P, T>(&self, path: P, target: T) -> SftpResult<Status>
     where
-        P: Into<String>,
-        T: Into<String>,
+        P: Into<OsString>,
+        T: Into<OsString>,
     {
         let id = self.use_next_id();
         let result = self

--- a/src/client/session.rs
+++ b/src/client/session.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{ffi::OsString, sync::Arc};
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
 use super::{
@@ -250,8 +250,8 @@ impl SftpSession {
 
     pub async fn hardlink<O, N>(&self, oldpath: O, newpath: N) -> SftpResult<bool>
     where
-        O: Into<String>,
-        N: Into<String>,
+        O: Into<OsString>,
+        N: Into<OsString>,
     {
         if !self.extensions.hardlink {
             return Ok(false);
@@ -262,7 +262,7 @@ impl SftpSession {
 
     /// Performs a statvfs on the remote file system path.
     /// Returns [`Ok(None)`] if the remote SFTP server does not support `statvfs@openssh.com` extension v2.
-    pub async fn fs_info<P: Into<String>>(&self, path: P) -> SftpResult<Option<Statvfs>> {
+    pub async fn fs_info<P: Into<OsString>>(&self, path: P) -> SftpResult<Option<Statvfs>> {
         if !self.extensions.statvfs {
             return Ok(None);
         }

--- a/src/client/session.rs
+++ b/src/client/session.rs
@@ -82,14 +82,14 @@ impl SftpSession {
     }
 
     /// Attempts to open a file in read-only mode.
-    pub async fn open<T: Into<String>>(&self, filename: T) -> SftpResult<File> {
+    pub async fn open<T: Into<OsString>>(&self, filename: T) -> SftpResult<File> {
         self.open_with_flags(filename, OpenFlags::READ).await
     }
 
     /// Opens a file in write-only mode.
     ///
     /// This function will create a file if it does not exist, and will truncate it if it does.
-    pub async fn create<T: Into<String>>(&self, filename: T) -> SftpResult<File> {
+    pub async fn create<T: Into<OsString>>(&self, filename: T) -> SftpResult<File> {
         self.open_with_flags(
             filename,
             OpenFlags::CREATE | OpenFlags::TRUNCATE | OpenFlags::WRITE,
@@ -98,7 +98,7 @@ impl SftpSession {
     }
 
     /// Attempts to open or create the file in the specified mode
-    pub async fn open_with_flags<T: Into<String>>(
+    pub async fn open_with_flags<T: Into<OsString>>(
         &self,
         filename: T,
         flags: OpenFlags,
@@ -124,7 +124,7 @@ impl SftpSession {
     }
 
     /// Requests the remote party for the absolute from the relative path.
-    pub async fn canonicalize<T: Into<String>>(&self, path: T) -> SftpResult<String> {
+    pub async fn canonicalize<T: Into<OsString>>(&self, path: T) -> SftpResult<OsString> {
         let name = self.session.realpath(path).await?;
         match name.files.first() {
             Some(file) => Ok(file.filename.to_owned()),
@@ -133,7 +133,7 @@ impl SftpSession {
     }
 
     /// Creates a new empty directory.
-    pub async fn create_dir<T: Into<String>>(&self, path: T) -> SftpResult<()> {
+    pub async fn create_dir<T: Into<OsString>>(&self, path: T) -> SftpResult<()> {
         self.session
             .mkdir(path, FileAttributes::default())
             .await
@@ -141,7 +141,7 @@ impl SftpSession {
     }
 
     /// Reads the contents of a file located at the specified path to the end.
-    pub async fn read<P: Into<String>>(&self, path: P) -> SftpResult<Vec<u8>> {
+    pub async fn read<P: Into<OsString>>(&self, path: P) -> SftpResult<Vec<u8>> {
         let mut file = self.open(path).await?;
         let mut buffer = Vec::new();
 
@@ -151,14 +151,14 @@ impl SftpSession {
     }
 
     /// Writes the contents to a file whose path is specified.
-    pub async fn write<P: Into<String>>(&self, path: P, data: &[u8]) -> SftpResult<()> {
+    pub async fn write<P: Into<OsString>>(&self, path: P, data: &[u8]) -> SftpResult<()> {
         let mut file = self.open_with_flags(path, OpenFlags::WRITE).await?;
         file.write_all(data).await?;
         Ok(())
     }
 
     /// Checks a file or folder exists at the specified path
-    pub async fn try_exists<P: Into<String>>(&self, path: P) -> SftpResult<bool> {
+    pub async fn try_exists<P: Into<OsString>>(&self, path: P) -> SftpResult<bool> {
         match self.metadata(path).await {
             Ok(_) => Ok(true),
             Err(Error::Status(status)) if status.status_code == StatusCode::NoSuchFile => Ok(false),
@@ -167,7 +167,7 @@ impl SftpSession {
     }
 
     /// Returns an iterator over the entries within a directory.
-    pub async fn read_dir<P: Into<String>>(&self, path: P) -> SftpResult<ReadDir> {
+    pub async fn read_dir<P: Into<OsString>>(&self, path: P) -> SftpResult<ReadDir> {
         let mut files = vec![];
         let handle = self.session.opendir(path).await?.handle;
 
@@ -194,7 +194,7 @@ impl SftpSession {
     }
 
     /// Reads a symbolic link, returning the file that the link points to.
-    pub async fn read_link<P: Into<String>>(&self, path: P) -> SftpResult<String> {
+    pub async fn read_link<P: Into<OsString>>(&self, path: P) -> SftpResult<OsString> {
         let name = self.session.readlink(path).await?;
         match name.files.first() {
             Some(file) => Ok(file.filename.to_owned()),
@@ -203,20 +203,20 @@ impl SftpSession {
     }
 
     /// Removes the specified folder.
-    pub async fn remove_dir<P: Into<String>>(&self, path: P) -> SftpResult<()> {
+    pub async fn remove_dir<P: Into<OsString>>(&self, path: P) -> SftpResult<()> {
         self.session.rmdir(path).await.map(|_| ())
     }
 
     /// Removes the specified file.
-    pub async fn remove_file<T: Into<String>>(&self, filename: T) -> SftpResult<()> {
+    pub async fn remove_file<T: Into<OsString>>(&self, filename: T) -> SftpResult<()> {
         self.session.remove(filename).await.map(|_| ())
     }
 
     /// Rename a file or directory to a new name.
     pub async fn rename<O, N>(&self, oldpath: O, newpath: N) -> SftpResult<()>
     where
-        O: Into<String>,
-        N: Into<String>,
+        O: Into<OsString>,
+        N: Into<OsString>,
     {
         self.session.rename(oldpath, newpath).await.map(|_| ())
     }
@@ -224,19 +224,19 @@ impl SftpSession {
     /// Creates a symlink of the specified target.
     pub async fn symlink<P, T>(&self, path: P, target: T) -> SftpResult<()>
     where
-        P: Into<String>,
-        T: Into<String>,
+        P: Into<OsString>,
+        T: Into<OsString>,
     {
         self.session.symlink(path, target).await.map(|_| ())
     }
 
     /// Queries metadata about the remote file.
-    pub async fn metadata<P: Into<String>>(&self, path: P) -> SftpResult<Metadata> {
+    pub async fn metadata<P: Into<OsString>>(&self, path: P) -> SftpResult<Metadata> {
         Ok(self.session.stat(path).await?.attrs)
     }
 
     /// Sets metadata for a remote file.
-    pub async fn set_metadata<P: Into<String>>(
+    pub async fn set_metadata<P: Into<OsString>>(
         &self,
         path: P,
         metadata: Metadata,
@@ -244,7 +244,7 @@ impl SftpSession {
         self.session.setstat(path, metadata).await.map(|_| ())
     }
 
-    pub async fn symlink_metadata<P: Into<String>>(&self, path: P) -> SftpResult<Metadata> {
+    pub async fn symlink_metadata<P: Into<OsString>>(&self, path: P) -> SftpResult<Metadata> {
         Ok(self.session.lstat(path).await?.attrs)
     }
 

--- a/src/extensions.rs
+++ b/src/extensions.rs
@@ -1,3 +1,5 @@
+use std::ffi::OsString;
+
 use crate::{error::Error, ser};
 
 pub const LIMITS: &str = "limits@openssh.com";
@@ -27,8 +29,8 @@ pub struct LimitsExtension {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct HardlinkExtension {
-    pub oldpath: String,
-    pub newpath: String,
+    pub oldpath: OsString,
+    pub newpath: OsString,
 }
 
 impl_try_into_bytes!(HardlinkExtension);
@@ -42,7 +44,7 @@ impl_try_into_bytes!(FsyncExtension);
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct StatvfsExtension {
-    pub path: String,
+    pub path: OsString,
 }
 
 impl_try_into_bytes!(StatvfsExtension);

--- a/src/protocol/file.rs
+++ b/src/protocol/file.rs
@@ -1,12 +1,15 @@
 use chrono::{DateTime, Utc};
-use std::time::{Duration, UNIX_EPOCH};
+use std::{
+    ffi::OsString,
+    time::{Duration, UNIX_EPOCH},
+};
 
 use super::FileAttributes;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct File {
-    pub filename: String,
-    pub longname: String,
+    pub filename: OsString,
+    pub longname: OsString,
     pub attrs: FileAttributes,
 }
 
@@ -23,7 +26,7 @@ impl File {
         let delayed = datetime.format("%b %d %Y %H:%M");
 
         format!(
-            "{directory}{permissions} 0 {} {} {size} {delayed} {}",
+            "{directory}{permissions} 0 {} {} {size} {delayed} {:?}",
             if let Some(user) = &self.attrs.user {
                 user.to_string()
             } else {

--- a/src/protocol/lstat.rs
+++ b/src/protocol/lstat.rs
@@ -1,10 +1,12 @@
+use std::ffi::OsString;
+
 use super::{impl_packet_for, impl_request_id, Packet, RequestId};
 
 /// Implementation for `SSH_FXP_LSTAT`
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Lstat {
     pub id: u32,
-    pub path: String,
+    pub path: OsString,
 }
 
 impl_request_id!(Lstat);

--- a/src/protocol/mkdir.rs
+++ b/src/protocol/mkdir.rs
@@ -1,10 +1,12 @@
+use std::ffi::OsString;
+
 use super::{impl_packet_for, impl_request_id, FileAttributes, Packet, RequestId};
 
 /// Implementation for `SSH_FXP_MKDIR`
 #[derive(Debug, Serialize, Deserialize)]
 pub struct MkDir {
     pub id: u32,
-    pub path: String,
+    pub path: OsString,
     pub attrs: FileAttributes,
 }
 

--- a/src/protocol/open.rs
+++ b/src/protocol/open.rs
@@ -1,4 +1,4 @@
-use std::fs;
+use std::{ffi::OsString, fs};
 
 use super::{impl_packet_for, impl_request_id, FileAttributes, Packet, RequestId};
 
@@ -54,7 +54,7 @@ impl From<OpenFlags> for fs::OpenOptions {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Open {
     pub id: u32,
-    pub filename: String,
+    pub filename: OsString,
     pub pflags: OpenFlags,
     pub attrs: FileAttributes,
 }

--- a/src/protocol/opendir.rs
+++ b/src/protocol/opendir.rs
@@ -1,10 +1,12 @@
+use std::ffi::OsString;
+
 use super::{impl_packet_for, impl_request_id, Packet, RequestId};
 
 /// Implementation for `SSH_FXP_OPENDIR`
 #[derive(Debug, Serialize, Deserialize)]
 pub struct OpenDir {
     pub id: u32,
-    pub path: String,
+    pub path: OsString,
 }
 
 impl_request_id!(OpenDir);

--- a/src/protocol/readlink.rs
+++ b/src/protocol/readlink.rs
@@ -1,10 +1,12 @@
+use std::ffi::OsString;
+
 use super::{impl_packet_for, impl_request_id, Packet, RequestId};
 
 /// Implementation for `SSH_FXP_READLINK`
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ReadLink {
     pub id: u32,
-    pub path: String,
+    pub path: OsString,
 }
 
 impl_request_id!(ReadLink);

--- a/src/protocol/realpath.rs
+++ b/src/protocol/realpath.rs
@@ -1,10 +1,12 @@
+use std::ffi::OsString;
+
 use super::{impl_packet_for, impl_request_id, Packet, RequestId};
 
 /// Implementation for `SSH_FXP_REALPATH`
 #[derive(Debug, Serialize, Deserialize)]
 pub struct RealPath {
     pub id: u32,
-    pub path: String,
+    pub path: OsString,
 }
 
 impl_request_id!(RealPath);

--- a/src/protocol/remove.rs
+++ b/src/protocol/remove.rs
@@ -1,10 +1,12 @@
+use std::ffi::OsString;
+
 use super::{impl_packet_for, impl_request_id, Packet, RequestId};
 
 /// Implementation for `SSH_FXP_REMOVE`
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Remove {
     pub id: u32,
-    pub filename: String,
+    pub filename: OsString,
 }
 
 impl_request_id!(Remove);

--- a/src/protocol/rename.rs
+++ b/src/protocol/rename.rs
@@ -1,11 +1,13 @@
+use std::ffi::OsString;
+
 use super::{impl_packet_for, impl_request_id, Packet, RequestId};
 
 /// Implementation for `SSH_FXP_RENAME`
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Rename {
     pub id: u32,
-    pub oldpath: String,
-    pub newpath: String,
+    pub oldpath: OsString,
+    pub newpath: OsString,
 }
 
 impl_request_id!(Rename);

--- a/src/protocol/rmdir.rs
+++ b/src/protocol/rmdir.rs
@@ -1,10 +1,12 @@
+use std::ffi::OsString;
+
 use super::{impl_packet_for, impl_request_id, Packet, RequestId};
 
 /// Implementation for `SSH_FXP_RMDIR`
 #[derive(Debug, Serialize, Deserialize)]
 pub struct RmDir {
     pub id: u32,
-    pub path: String,
+    pub path: OsString,
 }
 
 impl_request_id!(RmDir);

--- a/src/protocol/setstat.rs
+++ b/src/protocol/setstat.rs
@@ -1,10 +1,12 @@
+use std::ffi::OsString;
+
 use super::{impl_packet_for, impl_request_id, FileAttributes, Packet, RequestId};
 
 /// Implementation for `SSH_FXP_SETSTAT` and `MKDIR`
 #[derive(Debug, Serialize, Deserialize)]
 pub struct SetStat {
     pub id: u32,
-    pub path: String,
+    pub path: OsString,
     pub attrs: FileAttributes,
 }
 

--- a/src/protocol/stat.rs
+++ b/src/protocol/stat.rs
@@ -1,10 +1,12 @@
+use std::ffi::OsString;
+
 use super::{impl_packet_for, impl_request_id, Packet, RequestId};
 
 /// Implementation for `SSH_FXP_STAT`
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Stat {
     pub id: u32,
-    pub path: String,
+    pub path: OsString,
 }
 
 impl_request_id!(Stat);

--- a/src/protocol/symlink.rs
+++ b/src/protocol/symlink.rs
@@ -1,11 +1,13 @@
+use std::ffi::OsString;
+
 use super::{impl_packet_for, impl_request_id, Packet, RequestId};
 
 /// Implementation for `SSH_FXP_SYMLINK`
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Symlink {
     pub id: u32,
-    pub linkpath: String,
-    pub targetpath: String,
+    pub linkpath: OsString,
+    pub targetpath: OsString,
 }
 
 impl_request_id!(Symlink);

--- a/src/server/handler.rs
+++ b/src/server/handler.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, ffi::OsString};
 
 use crate::protocol::{
     Attrs, Data, FileAttributes, Handle, Name, OpenFlags, Packet, Status, StatusCode, Version,
@@ -31,7 +31,7 @@ pub trait Handler: Sized {
     async fn open(
         &mut self,
         id: u32,
-        filename: String,
+        filename: OsString,
         pflags: OpenFlags,
         attrs: FileAttributes,
     ) -> Result<Handle, Self::Error> {
@@ -71,7 +71,7 @@ pub trait Handler: Sized {
 
     /// Called on SSH_FXP_LSTAT
     #[allow(unused_variables)]
-    async fn lstat(&mut self, id: u32, path: String) -> Result<Attrs, Self::Error> {
+    async fn lstat(&mut self, id: u32, path: OsString) -> Result<Attrs, Self::Error> {
         Err(self.unimplemented())
     }
 
@@ -86,7 +86,7 @@ pub trait Handler: Sized {
     async fn setstat(
         &mut self,
         id: u32,
-        path: String,
+        path: OsString,
         attrs: FileAttributes,
     ) -> Result<Status, Self::Error> {
         Err(self.unimplemented())
@@ -105,7 +105,7 @@ pub trait Handler: Sized {
 
     /// Called on SSH_FXP_OPENDIR
     #[allow(unused_variables)]
-    async fn opendir(&mut self, id: u32, path: String) -> Result<Handle, Self::Error> {
+    async fn opendir(&mut self, id: u32, path: OsString) -> Result<Handle, Self::Error> {
         Err(self.unimplemented())
     }
 
@@ -119,7 +119,7 @@ pub trait Handler: Sized {
     /// Called on SSH_FXP_REMOVE.
     /// The status can be returned as Ok or as Err
     #[allow(unused_variables)]
-    async fn remove(&mut self, id: u32, filename: String) -> Result<Status, Self::Error> {
+    async fn remove(&mut self, id: u32, filename: OsString) -> Result<Status, Self::Error> {
         Err(self.unimplemented())
     }
 
@@ -128,7 +128,7 @@ pub trait Handler: Sized {
     async fn mkdir(
         &mut self,
         id: u32,
-        path: String,
+        path: OsString,
         attrs: FileAttributes,
     ) -> Result<Status, Self::Error> {
         Err(self.unimplemented())
@@ -137,20 +137,20 @@ pub trait Handler: Sized {
     /// Called on SSH_FXP_RMDIR.
     /// The status can be returned as Ok or as Err
     #[allow(unused_variables)]
-    async fn rmdir(&mut self, id: u32, path: String) -> Result<Status, Self::Error> {
+    async fn rmdir(&mut self, id: u32, path: OsString) -> Result<Status, Self::Error> {
         Err(self.unimplemented())
     }
 
     /// Called on SSH_FXP_REALPATH.
     /// Must contain only one name and a dummy attributes
     #[allow(unused_variables)]
-    async fn realpath(&mut self, id: u32, path: String) -> Result<Name, Self::Error> {
+    async fn realpath(&mut self, id: u32, path: OsString) -> Result<Name, Self::Error> {
         Err(self.unimplemented())
     }
 
     /// Called on SSH_FXP_STAT
     #[allow(unused_variables)]
-    async fn stat(&mut self, id: u32, path: String) -> Result<Attrs, Self::Error> {
+    async fn stat(&mut self, id: u32, path: OsString) -> Result<Attrs, Self::Error> {
         Err(self.unimplemented())
     }
 
@@ -160,15 +160,15 @@ pub trait Handler: Sized {
     async fn rename(
         &mut self,
         id: u32,
-        oldpath: String,
-        newpath: String,
+        oldpath: OsString,
+        newpath: OsString,
     ) -> Result<Status, Self::Error> {
         Err(self.unimplemented())
     }
 
     /// Called on SSH_FXP_READLINK
     #[allow(unused_variables)]
-    async fn readlink(&mut self, id: u32, path: String) -> Result<Name, Self::Error> {
+    async fn readlink(&mut self, id: u32, path: OsString) -> Result<Name, Self::Error> {
         Err(self.unimplemented())
     }
 
@@ -178,8 +178,8 @@ pub trait Handler: Sized {
     async fn symlink(
         &mut self,
         id: u32,
-        linkpath: String,
-        targetpath: String,
+        linkpath: OsString,
+        targetpath: OsString,
     ) -> Result<Status, Self::Error> {
         Err(self.unimplemented())
     }


### PR DESCRIPTION
Fixes #42 
