### PR TITLE
Update Russh

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,8 @@ log = "0.4"
 flurry = "0.5"
 
 [dev-dependencies]
-russh = "0.43"
-russh-keys = "0.43"
+russh = "0.45.0"
+russh-keys = "0.45.0"
 env_logger = "0.11"
 anyhow = "1.0"
 criterion = { version = "0.5", features = ["async_tokio"] }


### PR DESCRIPTION
Updated `russh` and `russh-keys` to `0.45.0` to address vulnerability 