### PR TITLE
Add missing use for public FilePermissions*

### DIFF
--- a/src/client/fs/file.rs
+++ b/src/client/fs/file.rs
@@ -31,7 +31,7 @@ struct FileState {
 
 /// Provides high-level methods for interaction with a remote file.
 ///
-/// Handle does not necessarily need to be closed because of the [`Drop`] mechanism.
+/// In order to properly close the handle, [`shutdown`] on a file should be called.
 /// Also implement [`AsyncSeek`] and other async i/o implementations.
 ///
 /// # Weakness

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -37,7 +37,9 @@ pub use self::{
     data::Data,
     extended::{Extended, ExtendedReply},
     file::File,
-    file_attrs::{FileAttr, FileAttributes, FileMode, FileType},
+    file_attrs::{
+        FileAttr, FileAttributes, FileMode, FilePermissionFlags, FilePermissions, FileType,
+    },
     fsetstat::FSetStat,
     fstat::Fstat,
     handle::Handle,


### PR DESCRIPTION
- since `FilePermissions` is not public, it's impossible to use `FileAttributes::permissions()`
- update info for a `File`, because Drop doesn't close the file properly