### PR TITLE
upgrade `bytes` version to 1.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ bitflags = { version = "2.8", features = ["serde"] }
 async-trait = "0.1"
 thiserror = "2.0"
 chrono = "0.4"
-bytes = "~1.9"
+bytes = "1.10.0"
 log = "0.4"
 flurry = "0.5"
 

--- a/src/buf.rs
+++ b/src/buf.rs
@@ -37,7 +37,7 @@ impl<T: Buf> TryBuf for T {
     }
 
     fn try_get_bytes(&mut self) -> Result<Vec<u8>, Error> {
-        let len = self.try_get_u32()? as usize;
+        let len = self.try_get_u32().map_err(|e|Error::UnexpectedBehavior(e.to_string()))? as usize;
         if self.remaining() < len {
             return Err(Error::BadMessage("no remaining for vec".to_owned()));
         }

--- a/src/de.rs
+++ b/src/de.rs
@@ -100,7 +100,7 @@ impl<'de> serde::Deserializer<'de> for &mut Deserializer<'de> {
     where
         V: serde::de::Visitor<'de>,
     {
-        visitor.visit_u8(self.input.try_get_u8()?)
+        visitor.visit_u8(TryBuf::try_get_u8(self.input)?)
     }
 
     fn deserialize_u16<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
@@ -114,14 +114,14 @@ impl<'de> serde::Deserializer<'de> for &mut Deserializer<'de> {
     where
         V: serde::de::Visitor<'de>,
     {
-        visitor.visit_u32(self.input.try_get_u32()?)
+        visitor.visit_u32(TryBuf::try_get_u32(self.input)?)
     }
 
     fn deserialize_u64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
         V: serde::de::Visitor<'de>,
     {
-        visitor.visit_u64(self.input.try_get_u64()?)
+        visitor.visit_u64(TryBuf::try_get_u64(self.input)?)
     }
 
     fn deserialize_f32<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
@@ -213,7 +213,7 @@ impl<'de> serde::Deserializer<'de> for &mut Deserializer<'de> {
     where
         V: serde::de::Visitor<'de>,
     {
-        let len = self.input.try_get_u32()? as usize;
+        let len = TryBuf::try_get_u32(self.input)? as usize;
         visitor.visit_seq(SeqDeserializer {
             de: self,
             len: Some(len),
@@ -389,7 +389,7 @@ impl<'de> EnumAccess<'de> for &mut Deserializer<'de> {
     where
         V: serde::de::DeserializeSeed<'de>,
     {
-        let v = IntoDeserializer::<Self::Error>::into_deserializer(self.input.try_get_u32()?);
+        let v = IntoDeserializer::<Self::Error>::into_deserializer(TryBuf::try_get_u32(self.input)?);
         Ok((seed.deserialize(v)?, self))
     }
 }


### PR DESCRIPTION
this PR include updating the version of `bytes` crate.
the new version of bytes includes some similar methods that are currently manually defined, i wasn't sure if they had the same exact behaviors so i just explicitly specified to call the `TryBuff` methods and not the `bytes::Bytes` on. 
the reason for upgrading the bytes version is mainly solving dependency conflicts.