### PR TITLE
remove unnecessary data cloning when writing file

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -9,9 +9,7 @@ pub fn unix(time: SystemTime) -> u32 {
     DateTime::<Utc>::from(time).timestamp() as u32
 }
 
-pub async fn read_packet<S: AsyncRead + Unpin>(
-    stream: &mut S,
-) -> Result<Bytes, Error> {
+pub async fn read_packet<S: AsyncRead + Unpin>(stream: &mut S) -> Result<Bytes, Error> {
     let length = stream.read_u32().await?;
 
     let mut buf = vec![0; length as usize];


### PR DESCRIPTION
Every time when a small part of a file was written, the remaining part of the file was unnecessarily copied.