### PR TITLE
feat(server): Add max packet length configuration

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -50,7 +50,7 @@ where
     S: AsyncRead + Unpin,
     H: Handler + Send,
 {
-    let mut bytes = read_packet(stream).await?;
+    let mut bytes = read_packet(stream, u32::MAX).await?;
     Ok(execute_handler(&mut bytes, handler).await?)
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -11,8 +11,13 @@ pub fn unix(time: SystemTime) -> u32 {
 
 pub async fn read_packet<S: AsyncRead + Unpin>(
     stream: &mut S,
+    max_length: u32,
 ) -> Result<Bytes, Error> {
     let length = stream.read_u32().await?;
+
+    if length > max_length {
+        return Err(Error::BadMessage("packet length limit exceeded".to_owned()));
+    }
 
     let mut buf = vec![0; length as usize];
     stream.read_exact(&mut buf).await?;


### PR DESCRIPTION
Adds a ServerConfig struct with only a single setting for now: max_packet_len.

This setting is used when reading packets to protect against potentially
malicious clients sending large packets.

Also adds a new run_with_config() function that takes a ServerConfig to 
prevent a breaking change.

run() now just uses the default config.
