### PR TITLE
perf: route Write/Data payloads through serde_bytes (~+29%)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ tokio = { version = "1", default-features = false, features = [
 ] }
 tokio-util = "0.7"
 serde = { version = "1.0", features = ["derive"] }
+serde_bytes = "0.11"
 bitflags = { version = "2.9", features = ["serde"] }
 async-trait = { version = "0.1", optional = true }
 

--- a/src/protocol/data.rs
+++ b/src/protocol/data.rs
@@ -4,6 +4,7 @@ use super::{impl_packet_for, impl_request_id, Packet, RequestId};
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Data {
     pub id: u32,
+    #[serde(with = "serde_bytes")]
     pub data: Vec<u8>,
 }
 

--- a/src/protocol/write.rs
+++ b/src/protocol/write.rs
@@ -6,6 +6,7 @@ pub struct Write {
     pub id: u32,
     pub handle: String,
     pub offset: u64,
+    #[serde(with = "serde_bytes")]
     pub data: Vec<u8>,
 }
 

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -103,8 +103,10 @@ impl<'a> serde::Serializer for &'a mut Serializer {
         Ok(())
     }
 
-    fn serialize_bytes(self, _v: &[u8]) -> Result<Self::Ok, Self::Error> {
-        Err(Error::BadMessage("bytes not supported".to_owned()))
+    fn serialize_bytes(self, v: &[u8]) -> Result<Self::Ok, Self::Error> {
+        self.output.put_u32(v.len() as u32);
+        self.output.put_slice(v);
+        Ok(())
     }
 
     fn serialize_none(self) -> Result<Self::Ok, Self::Error> {


### PR DESCRIPTION
## Motivation

The `data: Vec<u8>` fields on `protocol::Write` and `protocol::Data` rely on serde's generic `Vec<T>` derive, which dispatches through `deserialize_seq` and walks the SFTP payload **one byte at a time** via `VecVisitor`. For a 1 GiB upload that's ~10⁹ visitor dispatches, each going through the full serde machinery for a single `u8`.

`perf record` on the server side of a 1 GiB SFTP upload shows:

```
42.11%  serde_core::de::impls::<impl Deserialize for Vec<T>>::deserialize::VecVisitor::visit_seq
 3.59%  aws_lc_0_39_1_CRYPTO_poly1305_update
 3.14%  aws_lc_0_39_1_ChaCha20_ctr32_avx2
```

Crypto is not the bottleneck — the serde hot path is.

Two existing issues report the symptom: #55 (closed without root cause, throughput far below `sftp` CLI) and #70 (open, upload throughput on 1 Gbps LAN orders of magnitude below expected).

## Change

Annotate the two fields with `#[serde(with = "serde_bytes")]`:

```rust
#[derive(Debug, Serialize, Deserialize)]
pub struct Write {
    pub id: u32,
    pub handle: String,
    pub offset: u64,
    #[serde(with = "serde_bytes")]
    pub data: Vec<u8>,
}
```

This routes `Vec<u8>` through `deserialize_byte_buf`, which the crate's own `Deserializer` **already implements** as a single bulk read via `TryBuf::try_get_bytes` (u32 length prefix + `copy_to_bytes`). No new deserializer logic is needed — just take the fast path that was there all along.

The matching `Serializer::serialize_bytes` was previously unreachable and returned `BadMessage("bytes not supported")`. It's now implemented with the same `u32 len + bytes` framing that `serialize_seq` was producing, so the wire format is unchanged.

Diff is 9 lines across 4 files (Cargo.toml adds `serde_bytes = \"0.11\"`).

## Wire compatibility

`deserialize_seq` reads `u32 len` then `len` bytes. `deserialize_byte_buf` (via `try_get_bytes`) reads `u32 len` then `len` bytes. Same framing on both sides. Verified end-to-end against a stock OpenSSH `sftp` client doing `put` of 1 GiB files — no protocol errors, byte-exact upload.

## Measured impact

1 GiB SFTP upload, OpenSSH `sftp` client → russh-sftp server, 5 runs each, reported as average:

| Host CPU | Before (master @ 2.1.1) | After (this PR) |
| --- | --- | --- |
| Xeon Silver 4214 (CPU-bound) | 74.8 MiB/s | **96.4 MiB/s** (+29%) |
| AMD EPYC 7742 (network-bound on 1 Gbps) | ~95 MiB/s | ~95 MiB/s (unchanged) |

OpenSSH `sftp-server` on the same Xeon host measures ~101 MiB/s, so the gap to the C reference implementation shrinks from ~26% to ~5%.

On hosts that are already network-bound the change is invisible, as expected.

## Test plan

- [x] `cargo check`
- [x] `cargo test --lib` (passes; note: there are 0 lib tests in the crate today)
- [x] End-to-end `sftp put` of 1 GiB random-byte files between OpenSSH client and russh-sftp-based server
- [x] Throughput comparison on two distinct CPU classes (CPU-bound and network-bound)

---

Happy to split the dependency bump into its own commit or adjust the commit message if preferred. Thanks for `russh-sftp`!