### PR TITLE
Reproducible Builds: Use dashmap crate for concurrent hashmap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ thiserror = "2.0"
 chrono = "0.4"
 bytes = "1.10"
 log = "0.4"
-flurry = "0.5"
+dashmap = "6"
 
 [dev-dependencies]
 russh = "0.51"

--- a/src/client/rawsession.rs
+++ b/src/client/rawsession.rs
@@ -1,5 +1,5 @@
 use bytes::Bytes;
-use flurry::HashMap;
+use dashmap::DashMap as HashMap;
 use std::{
     sync::{
         atomic::{AtomicU32, AtomicU64, Ordering},
@@ -36,7 +36,7 @@ pub(crate) struct SessionInner {
 
 impl SessionInner {
     pub async fn reply(&mut self, id: Option<u32>, packet: Packet) -> SftpResult<()> {
-        if let Some(sender) = self.requests.pin().remove(&id) {
+        if let Some((_, sender)) = Arc::pin(&self.requests).remove(&id) {
             let validate = if id.is_some() && self.version.is_none() {
                 Err(Error::UnexpectedPacket)
             } else if id.is_none() && self.version.is_some() {
@@ -204,7 +204,7 @@ impl RawSftpSession {
 
         let (tx, mut rx) = mpsc::channel(1);
 
-        self.requests.pin().insert(id, tx);
+        Arc::pin(&self.requests).insert(id, tx);
         self.tx.send(Bytes::try_from(packet)?)?;
 
         let timeout = *self.options.timeout.read().await;
@@ -212,11 +212,11 @@ impl RawSftpSession {
         match time::timeout(Duration::from_secs(timeout), rx.recv()).await {
             Ok(Some(result)) => result,
             Ok(None) => {
-                self.requests.pin().remove(&id);
+                Arc::pin(&self.requests).remove(&id);
                 Err(Error::UnexpectedBehavior("recv none message".into()))
             }
             Err(error) => {
-                self.requests.pin().remove(&id);
+                Arc::pin(&self.requests).remove(&id);
                 Err(error.into())
             }
         }


### PR DESCRIPTION
Hello!

I use russh-sftp in a project and noticed the concurrent hashmap used by russh-sftp hardcodes a feature in ahash that reads from a random number generator during compile and adds those bytes into the compiled binary. This causes problems for systems like [reproducible.archlinux.org](https://reproducible.archlinux.org) or [reproduce.debian.net](https://reproduce.debian.net), that rely on deterministic compiles to detect build server compromises.

I filed [an issue](https://github.com/jonhoo/flurry/issues/135) but got no reply, so this patch replaces flurry with dashmap (which is also a more popular/common choice). This upstreams the patch I also applied to the [russh-sftp Debian package](https://packages.debian.org/sid/librust-russh-sftp-dev).

Thanks for making this crate!