### PR TITLE
Support the check-file SFTP extension

### DIFF
--- a/src/client/error.rs
+++ b/src/client/error.rs
@@ -26,6 +26,9 @@ pub enum Error {
     /// Occurs when unexpected server behavior differs from the protocol specifition
     #[error("{0}")]
     UnexpectedBehavior(String),
+    /// Occurs when the server does not advertise support for a requested extension
+    #[error("Unsupported extension: {0}")]
+    Unsupported(String),
 }
 
 impl From<Status> for Error {

--- a/src/client/rawsession.rs
+++ b/src/client/rawsession.rs
@@ -17,7 +17,8 @@ use crate::{
     client::{run, Config},
     de,
     extensions::{
-        self, FsyncExtension, HardlinkExtension, LimitsExtension, Statvfs, StatvfsExtension,
+        self, CheckFile, CheckFileExtension, FsyncExtension, HardlinkExtension, LimitsExtension,
+        Statvfs, StatvfsExtension,
     },
     protocol::{
         Attrs, Close, Data, Extended, ExtendedReply, FSetStat, FileAttributes, Fstat, Handle, Init,
@@ -739,6 +740,76 @@ impl RawSftpSession {
             }
             _ => Err(Error::UnexpectedPacket),
         }
+    }
+
+    async fn check_file<I: Into<String>, A: Into<String>>(
+        &self,
+        request: &str,
+        identifier: I,
+        algorithms: A,
+        start_offset: u64,
+        length: u64,
+        block_size: u32,
+    ) -> SftpResult<CheckFile> {
+        let result = self
+            .extended(
+                request,
+                CheckFileExtension {
+                    identifier: identifier.into(),
+                    hash_algorithm_list: algorithms.into(),
+                    start_offset,
+                    length,
+                    block_size,
+                }
+                .try_into()?,
+            )
+            .await?;
+
+        match result {
+            Packet::ExtendedReply(reply) => Ok(de::from_bytes::<CheckFile>(&mut reply.data.into())?),
+            Packet::Status(status) if status.status_code != StatusCode::Ok => {
+                Err(Error::Status(status))
+            }
+            _ => Err(Error::UnexpectedPacket),
+        }
+    }
+
+    pub async fn check_file_name<P: Into<String>, A: Into<String>>(
+        &self,
+        path: P,
+        algorithms: A,
+        start_offset: u64,
+        length: u64,
+        block_size: u32,
+    ) -> SftpResult<CheckFile> {
+        self.check_file(
+            extensions::CHECK_FILE_NAME,
+            path,
+            algorithms,
+            start_offset,
+            length,
+            block_size,
+        )
+        .await
+    }
+
+    pub async fn check_file_handle<H: Into<String>, A: Into<String>>(
+        &self,
+        handle: H,
+        algorithms: A,
+        start_offset: u64,
+        length: u64,
+        block_size: u32,
+    ) -> SftpResult<CheckFile> {
+        self.check_file(
+            extensions::CHECK_FILE_HANDLE,
+            handle,
+            algorithms,
+            start_offset,
+            length,
+            block_size,
+        )
+        .await
     }
 }
 

--- a/src/client/session.rs
+++ b/src/client/session.rs
@@ -9,7 +9,7 @@ use super::{
 };
 use crate::{
     client::Config,
-    extensions::{self, Statvfs},
+    extensions::{self, CheckFile, Statvfs},
     protocol::{FileAttributes, OpenFlags, StatusCode},
 };
 
@@ -28,6 +28,7 @@ pub(crate) struct Features {
 pub struct SftpSession {
     session: Arc<RawSftpSession>,
     features: Features,
+    check_file_algorithms: Option<String>,
 }
 
 impl SftpSession {
@@ -51,6 +52,9 @@ impl SftpSession {
         let version = session.init().await?;
         let has_extension = |name, ver| version.extensions.get(name).is_some_and(|v| v == ver);
 
+        // check-file's value is a hash-algorithm list, not a version number — detect by presence.
+        let check_file_algorithms = version.extensions.get(extensions::CHECK_FILE).cloned();
+
         let mut features = Features {
             hardlink: has_extension(extensions::HARDLINK, "1"),
             fsync: has_extension(extensions::FSYNC, "1"),
@@ -72,6 +76,7 @@ impl SftpSession {
         Ok(Self {
             session: Arc::new(session),
             features,
+            check_file_algorithms,
         })
     }
 
@@ -272,5 +277,30 @@ impl SftpSession {
         }
 
         self.session.statvfs(path).await.map(Some)
+    }
+
+    /// Hash algorithms the server advertises for the `check-file` extension
+    /// (comma-separated, in server preference order), or `None` if unsupported.
+    pub fn check_file_algorithms(&self) -> Option<&str> {
+        self.check_file_algorithms.as_deref()
+    }
+
+    /// Computes hashes of a remote file using the `check-file` extension.
+    /// Returns [`Error::Unsupported`] if the server does not advertise it.
+    pub async fn check_file<P: Into<String>, A: Into<String>>(
+        &self,
+        path: P,
+        algorithms: A,
+        start_offset: u64,
+        length: u64,
+        block_size: u32,
+    ) -> SftpResult<CheckFile> {
+        if self.check_file_algorithms.is_none() {
+            return Err(Error::Unsupported(extensions::CHECK_FILE.to_owned()));
+        }
+
+        self.session
+            .check_file_name(path, algorithms, start_offset, length, block_size)
+            .await
     }
 }

--- a/src/extensions.rs
+++ b/src/extensions.rs
@@ -1,9 +1,12 @@
-use crate::{error::Error, ser};
+use crate::{de::data_deserialize, error::Error, ser};
 
 pub const LIMITS: &str = "limits@openssh.com";
 pub const HARDLINK: &str = "hardlink@openssh.com";
 pub const FSYNC: &str = "fsync@openssh.com";
 pub const STATVFS: &str = "statvfs@openssh.com";
+pub const CHECK_FILE: &str = "check-file";
+pub const CHECK_FILE_NAME: &str = "check-file-name";
+pub const CHECK_FILE_HANDLE: &str = "check-file-handle";
 
 macro_rules! impl_try_into_bytes {
     ($struct:ty) => {
@@ -46,6 +49,24 @@ pub struct StatvfsExtension {
 }
 
 impl_try_into_bytes!(StatvfsExtension);
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CheckFileExtension {
+    pub identifier: String,
+    pub hash_algorithm_list: String,
+    pub start_offset: u64,
+    pub length: u64,
+    pub block_size: u32,
+}
+
+impl_try_into_bytes!(CheckFileExtension);
+
+#[derive(Debug, Deserialize)]
+pub struct CheckFile {
+    pub hash_algorithm: String,
+    #[serde(deserialize_with = "data_deserialize")]
+    pub hashes: Vec<u8>,
+}
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Statvfs {


### PR DESCRIPTION
# Add client support for the check-file SFTP extension

Adds client-side support for the `check-file` extension, which lets a client request server-computed hashes of a remote file — or a byte range of it — without downloading the data. Useful for verifying that a local copy matches the remote, resuming transfers, and dedup checks.

## What's added

- **Detection** — read from the `SSH_FXP_VERSION` `check-file` extension pair. Its value is the server's hash-algorithm list (not a version number), so support is detected by presence.
- **`extensions::{CheckFileExtension, CheckFile}`** — request/response structs built on the existing `SSH_FXP_EXTENDED` infrastructure (`impl_try_into_bytes!`, `data_deserialize`); no new abstraction layers.
- **`RawSftpSession::check_file_name` / `check_file_handle`** — both draft request variants (by path and by open handle), sharing one private helper.
- **`SftpSession::check_file(path, algorithms, start_offset, length, block_size)`** — high-level API; returns the new `Error::Unsupported` when the server doesn't advertise the extension. **`SftpSession::check_file_algorithms()`** exposes the advertised algorithm list so callers can pick one.

## Wire format / interoperability

Verified against both the draft and ProFTPD's `mod_sftp` (a deployed implementation):

- **Request:** `string id · string algo-list · uint64 start-offset · uint64 length · uint32 block-size`
- **Reply (`SSH_FXP_EXTENDED_REPLY`):** `string algo-used` followed by the raw concatenated per-block digests — no length prefix, no separators.

`CheckFile.hashes` is returned as the raw byte buffer; the caller splits it by the digest size of the chosen algorithm. A `block_size` of `0` requests a single digest over the whole range.