### PR TITLE
feat(server): return JoinHandle from run/run_with_config

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -95,8 +95,14 @@ where
     Ok(())
 }
 
-/// Run processing stream as SFTP
-pub async fn run<S, H>(stream: S, handler: H)
+/// Run processing stream as SFTP.
+///
+/// The SFTP request loop is spawned onto a background task; the returned
+/// [`tokio::task::JoinHandle`] resolves once the client closes the stream
+/// (EOF). Awaiting it lets callers observe when the session ends — e.g. to
+/// close the underlying transport/channel afterwards. The handle may simply
+/// be dropped to keep the previous fire-and-forget behaviour.
+pub async fn run<S, H>(stream: S, handler: H) -> tokio::task::JoinHandle<()>
 where
     S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
     H: Handler + Send + 'static,
@@ -104,8 +110,14 @@ where
     run_with_config(stream, handler, Config::default()).await
 }
 
-/// Run processing stream as SFTP with custom configuration
-pub async fn run_with_config<S, H>(mut stream: S, mut handler: H, cfg: Config)
+/// Run processing stream as SFTP with custom configuration.
+///
+/// See [`run`] for details on the returned [`tokio::task::JoinHandle`].
+pub async fn run_with_config<S, H>(
+    mut stream: S,
+    mut handler: H,
+    cfg: Config,
+) -> tokio::task::JoinHandle<()>
 where
     S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
     H: Handler + Send + 'static,
@@ -120,5 +132,5 @@ where
         }
 
         debug!("sftp stream ended");
-    });
+    })
 }


### PR DESCRIPTION
## Motivation

`server::run` / `run_with_config` spawn the SFTP request loop on a detached task and return `()`, so callers can't observe when the SFTP session ends.

This matters for SSH servers embedding russh-sftp: after the SFTP subsystem finishes, the server usually needs to send the channel **EOF/CLOSE** to complete the SSH channel-close handshake. With no completion signal, it can't — and clients that strictly wait for the server's `SSH_MSG_CHANNEL_CLOSE` (**sshj/JSch**-based clients such as **Cyberduck** and **PyCharm/IntelliJ**) hang until their own timeout (~30s), while more lenient clients (OpenSSH `sftp`, FileZilla) tolerate the missing close. We hit exactly this in a downstream server.

## Change

Return the spawned task's `JoinHandle<()>` from `run` and `run_with_config`. The handle resolves once the client closes the stream (EOF).

**Backward compatible:** existing callers that write `run(stream, handler).await;` just drop the handle and keep the previous fire-and-forget behaviour (the bundled `examples/server.rs` is unchanged and still compiles). Callers that need cleanup can now:

```rust
let done = russh_sftp::server::run(channel.into_stream(), handler).await;
tokio::spawn(async move {
    let _ = done.await;                 // wait for the SFTP session to end
    let _ = handle.eof(channel_id).await;
    let _ = handle.close(channel_id).await;
});
```

`cargo check` passes; no other API changes.