### PR TITLE
feat: add expand-path@openssh.com extension support (client)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The main idea of the project is to provide an implementation for interacting wit
 - [x] Server side
 - [x] Simple server example
 - [ ] Full server example
-- [x] Extension support: `limits@openssh.com`, `hardlink@openssh.com`, `fsync@openssh.com`, `statvfs@openssh.com`
+- [x] Extension support: `limits@openssh.com`, `hardlink@openssh.com`, `fsync@openssh.com`, `statvfs@openssh.com`, `expand-path@openssh.com` (client only)
 - [ ] Unit tests
 - [x] Workflow
 

--- a/src/client/rawsession.rs
+++ b/src/client/rawsession.rs
@@ -17,7 +17,8 @@ use crate::{
     client::{run, Config},
     de,
     extensions::{
-        self, FsyncExtension, HardlinkExtension, LimitsExtension, Statvfs, StatvfsExtension,
+        self, ExpandPathExtension, FsyncExtension, HardlinkExtension, LimitsExtension, Statvfs,
+        StatvfsExtension,
     },
     protocol::{
         Attrs, Close, Data, Extended, ExtendedReply, FSetStat, FileAttributes, Fstat, Handle, Init,
@@ -580,6 +581,20 @@ impl RawSftpSession {
                     path: path.into(),
                 }
                 .into(),
+            )
+            .await?;
+
+        into_with_status!(result, Name)
+    }
+
+    /// Expands `~`/`~user` and canonicalises the path, via the
+    /// `expand-path@openssh.com` extension. Replies in the same format as
+    /// [`RawSftpSession::realpath`].
+    pub async fn expand_path<P: Into<String>>(&self, path: P) -> SftpResult<Name> {
+        let result = self
+            .extended(
+                extensions::EXPAND_PATH,
+                ExpandPathExtension { path: path.into() }.try_into()?,
             )
             .await?;
 

--- a/src/client/session.rs
+++ b/src/client/session.rs
@@ -18,6 +18,7 @@ pub(crate) struct Features {
     pub hardlink: bool,
     pub fsync: bool,
     pub statvfs: bool,
+    pub expand_path: bool,
     pub limits: Option<Limits>,
     pub max_concurrent_writes: usize,
     pub max_packet_len: u32,
@@ -55,6 +56,7 @@ impl SftpSession {
             hardlink: has_extension(extensions::HARDLINK, "1"),
             fsync: has_extension(extensions::FSYNC, "1"),
             statvfs: has_extension(extensions::STATVFS, "2"),
+            expand_path: has_extension(extensions::EXPAND_PATH, "1"),
             limits: None,
             max_concurrent_writes,
             max_packet_len,
@@ -128,6 +130,22 @@ impl SftpSession {
         let name = self.session.realpath(path).await?;
         match name.files.first() {
             Some(file) => Ok(file.filename.to_owned()),
+            None => Err(Error::UnexpectedBehavior("no file".to_owned())),
+        }
+    }
+
+    /// Expands a `~`/`~user`-prefixed or relative path and returns its
+    /// canonicalised absolute form, via the `expand-path@openssh.com`
+    /// extension. Returns [`Ok(None)`] if the remote SFTP server does not
+    /// support the extension.
+    pub async fn expand_path<T: Into<String>>(&self, path: T) -> SftpResult<Option<String>> {
+        if !self.features.expand_path {
+            return Ok(None);
+        }
+
+        let name = self.session.expand_path(path).await?;
+        match name.files.first() {
+            Some(file) => Ok(Some(file.filename.to_owned())),
             None => Err(Error::UnexpectedBehavior("no file".to_owned())),
         }
     }

--- a/src/extensions.rs
+++ b/src/extensions.rs
@@ -4,6 +4,7 @@ pub const LIMITS: &str = "limits@openssh.com";
 pub const HARDLINK: &str = "hardlink@openssh.com";
 pub const FSYNC: &str = "fsync@openssh.com";
 pub const STATVFS: &str = "statvfs@openssh.com";
+pub const EXPAND_PATH: &str = "expand-path@openssh.com";
 
 macro_rules! impl_try_into_bytes {
     ($struct:ty) => {
@@ -46,6 +47,13 @@ pub struct StatvfsExtension {
 }
 
 impl_try_into_bytes!(StatvfsExtension);
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ExpandPathExtension {
+    pub path: String,
+}
+
+impl_try_into_bytes!(ExpandPathExtension);
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Statvfs {


### PR DESCRIPTION
## Summary
- Adds client support for the `expand-path@openssh.com` SFTP extension.

🤖 Generated with [Claude Code](https://claude.com/claude-code)