### PR TITLE
Introduce secondary timeout

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -13,7 +13,7 @@ use bytes::Bytes;
 use tokio::{
     io::{self, AsyncRead, AsyncWrite, AsyncWriteExt},
     select,
-    sync::mpsc,
+    sync::{mpsc, oneshot},
 };
 use tokio_util::sync::CancellationToken;
 
@@ -75,14 +75,18 @@ where
     Ok(execute_handler(&mut bytes, handler).await?)
 }
 
+/// A queued outgoing packet, paired with an optional notification that
+/// fires once the bytes have actually been handed to the socket.
+pub(crate) type WriteItem = (Bytes, Option<oneshot::Sender<()>>);
+
 /// Run processing stream as SFTP client. Is a simple handler of incoming
 /// and outgoing packets. Can be used for non-standard implementations
-pub fn run<S, H>(stream: S, mut handler: H) -> mpsc::UnboundedSender<Bytes>
+pub fn run<S, H>(stream: S, mut handler: H) -> mpsc::UnboundedSender<WriteItem>
 where
     S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
     H: Handler + Send + 'static,
 {
-    let (tx, mut rx) = mpsc::unbounded_channel::<Bytes>();
+    let (tx, mut rx) = mpsc::unbounded_channel::<WriteItem>();
     let (mut rd, mut wr) = io::split(stream);
 
     let rc = CancellationToken::new();
@@ -110,13 +114,20 @@ where
     runtime::spawn(async move {
         loop {
             select! {
-                Some(data) = rx.recv() => {
+                Some((data, sent)) = rx.recv() => {
                     if data.is_empty() {
                         let _ = wr.shutdown().await;
                         break;
                     }
 
                     let _ = wr.write_all(&data[..]).await;
+
+                    // Signal that the packet has actually been handed to
+                    // the socket, so the caller can start its response
+                    // timeout from here rather than from enqueue time.
+                    if let Some(sent) = sent {
+                        let _ = sent.send(());
+                    }
                 },
                 _ = wc.cancelled() => break,
             }

--- a/src/client/rawsession.rs
+++ b/src/client/rawsession.rs
@@ -2,8 +2,8 @@ use bytes::Bytes;
 use dashmap::DashMap as HashMap;
 use std::{
     sync::{
-        atomic::{AtomicU32, AtomicU64, Ordering},
         Arc,
+        atomic::{AtomicU32, AtomicU64, Ordering},
     },
     time::Duration,
 };
@@ -12,9 +12,9 @@ use tokio::{
     sync::{mpsc, oneshot},
 };
 
-use super::{error::Error, runtime, Handler};
+use super::{Handler, WriteItem, error::Error, runtime};
 use crate::{
-    client::{run, Config},
+    client::{Config, run},
     de,
     extensions::{
         self, FsyncExtension, HardlinkExtension, LimitsExtension, Statvfs, StatvfsExtension,
@@ -117,7 +117,7 @@ impl From<LimitsExtension> for Limits {
 /// then the packet is returned as Ok in other error cases
 /// the packet is stored as Err.
 pub struct RawSftpSession {
-    tx: mpsc::UnboundedSender<Bytes>,
+    tx: mpsc::UnboundedSender<WriteItem>,
     requests: Arc<SharedRequests>,
     next_req_id: AtomicU32,
     handles: AtomicU64,
@@ -184,11 +184,14 @@ impl RawSftpSession {
         self.limits = limits;
     }
 
+    /// Enqueues `packet` for sending and returns a receiver for its reply,
+    /// plus a receiver that resolves once the bytes have actually been
+    /// handed to the socket
     fn send(
         &self,
         id: Option<u32>,
         packet: Packet,
-    ) -> SftpResult<oneshot::Receiver<SftpResult<Packet>>> {
+    ) -> SftpResult<(oneshot::Receiver<SftpResult<Packet>>, oneshot::Receiver<()>)> {
         if self.tx.is_closed() {
             return Err(Error::UnexpectedBehavior("session closed".into()));
         }
@@ -203,14 +206,33 @@ impl RawSftpSession {
 
         let (tx, rx) = oneshot::channel();
         self.requests.insert(id, tx);
-        self.tx.send(bytes)?;
 
-        Ok(rx)
+        let (sent_tx, sent_rx) = oneshot::channel();
+        self.tx.send((bytes, Some(sent_tx)))?;
+
+        Ok((rx, sent_rx))
     }
 
     async fn request(&self, id: Option<u32>, packet: Packet) -> SftpResult<Packet> {
-        let rx = self.send(id, packet)?;
+        let (rx, sent_rx) = self.send(id, packet)?;
         let timeout = self.timeout.load(Ordering::Relaxed);
+
+        // The response timeout must only start once the packet has actually
+        // left the host; otherwise a backed-up writer (e.g. from pipelined
+        // write_nowait calls) can time out requests that are still sitting
+        // in the local queue. Bound this wait too, so a genuinely stuck
+        // writer still surfaces as a timeout rather than hanging forever.
+        match runtime::timeout(Duration::from_secs(600), sent_rx).await {
+            Ok(Ok(())) => (),
+            Ok(Err(_)) => {
+                self.requests.remove(&id);
+                return Err(Error::UnexpectedBehavior("write channel closed".into()));
+            }
+            Err(error) => {
+                self.requests.remove(&id);
+                return Err(error);
+            }
+        }
 
         match runtime::timeout(Duration::from_secs(timeout), rx).await {
             Ok(Ok(result)) => result,
@@ -232,7 +254,7 @@ impl RawSftpSession {
             return Ok(());
         }
 
-        Ok(self.tx.send(Bytes::new())?)
+        Ok(self.tx.send((Bytes::new(), None))?)
     }
 
     pub async fn init(&self) -> SftpResult<Version> {
@@ -297,11 +319,7 @@ impl RawSftpSession {
                 && self
                     .handles
                     .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |h| {
-                        if h > 0 {
-                            Some(h - 1)
-                        } else {
-                            None
-                        }
+                        if h > 0 { Some(h - 1) } else { None }
                     })
                     .is_err()
             {
@@ -318,7 +336,8 @@ impl RawSftpSession {
         handle: String,
     ) -> SftpResult<oneshot::Receiver<SftpResult<Packet>>> {
         let id = self.use_next_id();
-        self.send(Some(id), Close { id, handle }.into())
+        let (rx, _sent) = self.send(Some(id), Close { id, handle }.into())?;
+        Ok(rx)
     }
 
     pub async fn read<H: Into<String>>(
@@ -387,7 +406,7 @@ impl RawSftpSession {
         }
 
         let id = self.use_next_id();
-        self.send(
+        let (rx, _sent) = self.send(
             Some(id),
             Write {
                 id,
@@ -396,7 +415,8 @@ impl RawSftpSession {
                 data,
             }
             .into(),
-        )
+        )?;
+        Ok(rx)
     }
 
     pub async fn lstat<P: Into<String>>(&self, path: P) -> SftpResult<Attrs> {


### PR DESCRIPTION
RawSftpSession::send() now returns a oneshot that resolves once the packet has actually been handed to the socket. request() waits on this signal before starting the configured timeout.

Previously the timeout clock started as soon as a packet was pushed onto the writer's unbounded channel, so a backed-up writer could time out requests before they even reached the wire.